### PR TITLE
fix: ten verified defects across orm, security and server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ on:
   push:
     branches:
       - main
+  # Without this, the only CI run that ever happens is the one on `main` — the
+  # same event that deploys Lore to production. Verification and deployment
+  # were literally the same moment, so a branch could only be proven green by
+  # shipping it. PRs get the full checks/test/bay/e2e matrix; the deploy jobs
+  # opt out below.
+  pull_request:
+    branches:
+      - main
   workflow_run:
     workflows: ["Release"]
     types:
@@ -222,6 +230,11 @@ jobs:
     # Docs deploy doesn't require the e2e job — only that the codebase
     # is lint/typecheck-clean and tests pass.
     needs: [checks, test]
+    # Publishing to GitHub Pages is a real side effect, so it must not fire for
+    # a proposed change. Phrased as "not a PR" rather than copying
+    # `deploy-lore-production`'s `push && ref == main`: docs also deploy on the
+    # `workflow_run` (Release) trigger, and that has to keep working.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/packages/alepha/src/orm/__tests__/DbCacheProvider.spec.ts
+++ b/packages/alepha/src/orm/__tests__/DbCacheProvider.spec.ts
@@ -1,0 +1,71 @@
+import { Alepha } from "alepha";
+import { DateTimeProvider } from "alepha/datetime";
+import { describe, expect, it } from "vitest";
+import { DbCacheProvider } from "../core/providers/DbCacheProvider.ts";
+
+class TestDbCacheProvider extends DbCacheProvider {
+  public size(): number {
+    return this.store.size;
+  }
+  public keys(): string[] {
+    return [...this.store.keys()];
+  }
+}
+
+const boot = async () => {
+  const alepha = Alepha.create();
+  const cache = alepha.inject(TestDbCacheProvider);
+  const dateTime = alepha.inject(DateTimeProvider);
+  await alepha.start();
+  return { cache, dateTime };
+};
+
+describe("DbCacheProvider", () => {
+  it("should evict the oldest entry once the capacity is reached", async () => {
+    const { cache } = await boot();
+
+    for (let i = 0; i < DbCacheProvider.MAX_ENTRIES + 10; i++) {
+      await cache.set("t", `k${i}`, i);
+    }
+
+    expect(cache.size()).toBeLessThanOrEqual(DbCacheProvider.MAX_ENTRIES);
+    // The very first keys are gone, the most recent survive.
+    expect(await cache.get("t", "k0")).toBeUndefined();
+    expect(await cache.get("t", `k${DbCacheProvider.MAX_ENTRIES + 9}`)).toBe(
+      DbCacheProvider.MAX_ENTRIES + 9,
+    );
+  });
+
+  it("should drop expired entries without needing them to be read", async () => {
+    const { cache, dateTime } = await boot();
+    dateTime.pause();
+
+    await cache.set("t", "short", 1, 1_000);
+    await cache.set("t", "long", 2, 3_600_000);
+    expect(cache.size()).toBe(2);
+
+    dateTime.travel(60_000);
+    // A write is the sweep trigger — nothing reads "short" ever again.
+    await cache.set("t", "other", 3, 3_600_000);
+
+    expect(cache.keys()).not.toContain("t:short");
+    expect(await cache.get("t", "long")).toBe(2);
+  });
+
+  it("should still serve a live entry", async () => {
+    const { cache } = await boot();
+    await cache.set("users", "findMany:{}", ["a"]);
+    expect(await cache.get("users", "findMany:{}")).toEqual(["a"]);
+  });
+
+  it("should still invalidate a whole table", async () => {
+    const { cache } = await boot();
+    await cache.set("users", "a", 1);
+    await cache.set("orders", "a", 2);
+
+    await cache.invalidateTable("users");
+
+    expect(await cache.get("users", "a")).toBeUndefined();
+    expect(await cache.get("orders", "a")).toBe(2);
+  });
+});

--- a/packages/alepha/src/orm/__tests__/query-cache-scope.spec.ts
+++ b/packages/alepha/src/orm/__tests__/query-cache-scope.spec.ts
@@ -1,0 +1,138 @@
+import { Alepha, z } from "alepha";
+import { currentTenantAtom, currentUserAtom } from "alepha/security";
+import { describe, expect, it } from "vitest";
+import { $entity, $repository, db } from "../core/index.ts";
+
+/**
+ * `opts.cache` is a performance knob. It must never widen what a read can see:
+ * the cache key has to carry the predicate the repository ADDS (tenant scope,
+ * soft-delete filter), not just the one the caller wrote.
+ */
+
+const ORG_A = "11111111-1111-1111-1111-111111111111";
+const ORG_B = "22222222-2222-2222-2222-222222222222";
+
+const docs = $entity({
+  name: "query_cache_docs",
+  schema: z.object({
+    id: db.primaryKey(),
+    organization: db.organization(),
+    title: z.text(),
+  }),
+});
+
+const softDocs = $entity({
+  name: "query_cache_soft_docs",
+  schema: z.object({
+    id: db.primaryKey(),
+    deletedAt: db.deletedAt(),
+    title: z.text(),
+  }),
+});
+
+class TenantApp {
+  docs = $repository(docs);
+}
+
+class SoftApp {
+  docs = $repository(softDocs);
+}
+
+const boot = <T extends object>(service: new () => T) => {
+  const alepha = Alepha.create({ env: { DATABASE_URL: "sqlite://:memory:" } });
+  const app = alepha.inject(service);
+  return { alepha, app };
+};
+
+const asOrg = <R>(alepha: Alepha, org: string, fn: () => Promise<R>) =>
+  alepha.context.run(() => {
+    alepha.store.set(currentUserAtom, {
+      id: `user-${org}`,
+      realm: "default",
+      roles: [],
+      organization: org,
+    });
+    return fn();
+  });
+
+describe("query cache is tenant-scoped", () => {
+  it("should not serve one organization's cached rows to another", async () => {
+    const { alepha, app } = boot(TenantApp);
+    await alepha.start();
+
+    await asOrg(alepha, ORG_A, () => app.docs.create({ title: "secret-A" }));
+    await asOrg(alepha, ORG_B, () => app.docs.create({ title: "secret-B" }));
+
+    const a = await asOrg(alepha, ORG_A, () =>
+      app.docs.findMany({ orderBy: "id" }, { cache: { ttl: 60_000 } }),
+    );
+    const b = await asOrg(alepha, ORG_B, () =>
+      app.docs.findMany({ orderBy: "id" }, { cache: { ttl: 60_000 } }),
+    );
+
+    expect(a.map((it) => it.title)).toEqual(["secret-A"]);
+    expect(b.map((it) => it.title)).toEqual(["secret-B"]);
+  });
+
+  it("should not serve a host-resolved tenant's cached rows to another", async () => {
+    const { alepha, app } = boot(TenantApp);
+    await alepha.start();
+
+    const asTenant = <R>(id: string, fn: () => Promise<R>) =>
+      alepha.context.run(() => {
+        alepha.store.set(currentTenantAtom, { id });
+        return fn();
+      });
+
+    await asTenant(ORG_A, () => app.docs.create({ title: "tenant-A" }));
+    await asTenant(ORG_B, () => app.docs.create({ title: "tenant-B" }));
+
+    const a = await asTenant(ORG_A, () =>
+      app.docs.findMany({ orderBy: "id" }, { cache: { ttl: 60_000 } }),
+    );
+    const b = await asTenant(ORG_B, () =>
+      app.docs.findMany({ orderBy: "id" }, { cache: { ttl: 60_000 } }),
+    );
+
+    expect(a.map((it) => it.title)).toEqual(["tenant-A"]);
+    expect(b.map((it) => it.title)).toEqual(["tenant-B"]);
+  });
+
+  it("should still hit the cache for two reads in the same tenant", async () => {
+    const { alepha, app } = boot(TenantApp);
+    await alepha.start();
+
+    await asOrg(alepha, ORG_A, () => app.docs.create({ title: "first" }));
+
+    const first = await asOrg(alepha, ORG_A, () =>
+      app.docs.findMany({ orderBy: "id" }, { cache: { ttl: 60_000 } }),
+    );
+
+    // A direct write that bypasses invalidation would still be masked by a
+    // live cache entry — which is exactly what "cache hit" means here.
+    const second = await asOrg(alepha, ORG_A, () =>
+      app.docs.findMany({ orderBy: "id" }, { cache: { ttl: 60_000 } }),
+    );
+
+    expect(second).toBe(first);
+  });
+});
+
+describe("query cache honours opts.force", () => {
+  it("should not let a force:true read poison a normal read", async () => {
+    const { alepha, app } = boot(SoftApp);
+    await alepha.start();
+
+    const row = await app.docs.create({ title: "gone" });
+    await app.docs.deleteById(row.id as number);
+
+    const forced = await app.docs.findMany(
+      {},
+      { force: true, cache: { ttl: 60_000 } },
+    );
+    const normal = await app.docs.findMany({}, { cache: { ttl: 60_000 } });
+
+    expect(forced.map((it) => it.title)).toEqual(["gone"]);
+    expect(normal).toEqual([]);
+  });
+});

--- a/packages/alepha/src/orm/__tests__/where-operator-guards.spec.ts
+++ b/packages/alepha/src/orm/__tests__/where-operator-guards.spec.ts
@@ -1,0 +1,112 @@
+import { Alepha, z } from "alepha";
+import { describe, expect, it } from "vitest";
+import { $entity, $repository, db } from "../core/index.ts";
+
+/**
+ * Regression tests for two where-clause shapes that TypeScript accepts (or
+ * that arrive as plain data from a request body / saved view) and that the
+ * query builder used to translate into something else entirely.
+ */
+
+const items = $entity({
+  name: "where_guard_items",
+  schema: z.object({
+    id: db.primaryKey(),
+    name: z.text(),
+    archivedAt: z.datetime().optional(),
+    tags: db.default(z.array(z.text()), []),
+  }),
+});
+
+class App {
+  repository = $repository(items);
+}
+
+const boot = async () => {
+  const alepha = Alepha.create({ env: { DATABASE_URL: "sqlite://:memory:" } });
+  const app = alepha.inject(App);
+  await alepha.start();
+  return app;
+};
+
+const seed = async (app: App) => {
+  await app.repository.create({
+    name: "archived",
+    archivedAt: "2026-01-01T00:00:00.000Z",
+    tags: ["x", "y"],
+  });
+  await app.repository.create({ name: "live", tags: ["z"] });
+};
+
+describe("isNull / isNotNull honour their value", () => {
+  it("should treat isNull: false as IS NOT NULL", async () => {
+    const app = await boot();
+    await seed(app);
+
+    const rows = await app.repository.findMany({
+      where: { archivedAt: { isNull: false } },
+    });
+
+    expect(rows.map((it) => it.name)).toEqual(["archived"]);
+  });
+
+  it("should treat isNotNull: false as IS NULL", async () => {
+    const app = await boot();
+    await seed(app);
+
+    const rows = await app.repository.findMany({
+      where: { archivedAt: { isNotNull: false } },
+    });
+
+    expect(rows.map((it) => it.name)).toEqual(["live"]);
+  });
+
+  it("should still treat isNull: true as IS NULL", async () => {
+    const app = await boot();
+    await seed(app);
+
+    const rows = await app.repository.findMany({
+      where: { archivedAt: { isNull: true } },
+    });
+
+    expect(rows.map((it) => it.name)).toEqual(["live"]);
+  });
+
+  it("should still treat isNotNull: true as IS NOT NULL", async () => {
+    const app = await boot();
+    await seed(app);
+
+    const rows = await app.repository.findMany({
+      where: { archivedAt: { isNotNull: true } },
+    });
+
+    expect(rows.map((it) => it.name)).toEqual(["archived"]);
+  });
+});
+
+describe("array shorthand on an array column", () => {
+  it("should compare the array as a value, not recurse into it", async () => {
+    const app = await boot();
+    await seed(app);
+
+    const rows = await app.repository.findMany({
+      where: { tags: ["x", "y"] },
+    });
+
+    expect(rows.map((it) => it.name)).toEqual(["archived"]);
+  });
+
+  it("should keep 'and' / 'or' arrays working", async () => {
+    const app = await boot();
+    await seed(app);
+
+    const rows = await app.repository.findMany({
+      where: {
+        or: [{ name: { eq: "archived" } }, { name: { eq: "live" } }],
+      },
+      orderBy: "name",
+    });
+
+    expect(rows.map((it) => it.name)).toEqual(["archived", "live"]);
+  });
+});

--- a/packages/alepha/src/orm/__tests__/write-payload-immutability.spec.ts
+++ b/packages/alepha/src/orm/__tests__/write-payload-immutability.spec.ts
@@ -1,0 +1,105 @@
+import { Alepha, z } from "alepha";
+import { describe, expect, it } from "vitest";
+import { $entity, $repository, db } from "../core/index.ts";
+
+/**
+ * A write must not edit the object the caller handed it. `updateMany` already
+ * copies before stamping `updatedAt`; `updateOne` and `upsert` did not, so a
+ * shared or reused patch came back carrying a column it never declared.
+ */
+
+const items = $entity({
+  name: "write_payload_items",
+  schema: z.object({
+    id: db.primaryKey(),
+    createdAt: db.createdAt(),
+    updatedAt: db.updatedAt(),
+    name: z.text(),
+  }),
+});
+
+class App {
+  repository = $repository(items);
+}
+
+const boot = async () => {
+  const alepha = Alepha.create({ env: { DATABASE_URL: "sqlite://:memory:" } });
+  const app = alepha.inject(App);
+  await alepha.start();
+  return app;
+};
+
+describe("writes do not mutate the caller's payload", () => {
+  it("should leave an updateById patch untouched", async () => {
+    const app = await boot();
+    const row = await app.repository.create({ name: "a" });
+
+    const patch = { name: "b" };
+    await app.repository.updateById(row.id as number, patch);
+
+    expect(Object.keys(patch)).toEqual(["name"]);
+  });
+
+  it("should leave an updateOne patch untouched", async () => {
+    const app = await boot();
+    await app.repository.create({ name: "a" });
+
+    const patch = { name: "b" };
+    await app.repository.updateOne({ name: { eq: "a" } }, patch);
+
+    expect(Object.keys(patch)).toEqual(["name"]);
+  });
+
+  it("should leave an upsert set clause untouched", async () => {
+    const app = await boot();
+    const created = await app.repository.create({ name: "a" });
+
+    const set = { name: "b" };
+    await app.repository.upsert({ id: created.id, name: "a" }, { set });
+
+    expect(Object.keys(set)).toEqual(["name"]);
+  });
+
+  it("should still stamp updatedAt on the persisted row", async () => {
+    const app = await boot();
+    const row = await app.repository.create({ name: "a" });
+    const before = row.updatedAt;
+
+    const updated = await app.repository.updateById(
+      row.id as number,
+      {
+        name: "b",
+        // biome-ignore lint/suspicious/noExplicitAny: forcing a distinct instant
+      } as any,
+      { now: "2030-01-01T00:00:00.000Z" },
+    );
+
+    expect(updated.updatedAt).not.toEqual(before);
+    expect(updated.name).toEqual("b");
+  });
+
+  it("should leave a reused StatementOptions untouched on destroy", async () => {
+    const softItems = $entity({
+      name: "write_payload_soft_items",
+      schema: z.object({
+        id: db.primaryKey(),
+        deletedAt: db.deletedAt(),
+        name: z.text(),
+      }),
+    });
+    class SoftApp {
+      repository = $repository(softItems);
+    }
+    const alepha = Alepha.create({
+      env: { DATABASE_URL: "sqlite://:memory:" },
+    });
+    const app = alepha.inject(SoftApp);
+    await alepha.start();
+
+    const row = await app.repository.create({ name: "a" });
+    const opts = {};
+    await app.repository.destroy(row, opts);
+
+    expect(Object.keys(opts)).toEqual([]);
+  });
+});

--- a/packages/alepha/src/orm/core/interfaces/FilterOperators.ts
+++ b/packages/alepha/src/orm/core/interfaces/FilterOperators.ts
@@ -151,11 +151,14 @@ export interface FilterOperators<TValue> {
    * ```ts
    * // Select cars that have been discontinued.
    * repository.findMany({ where: { discontinuedAt: { isNotNull: true } } })
+   *
+   * // `false` inverts the test, so a computed flag reads naturally.
+   * repository.findMany({ where: { discontinuedAt: { isNotNull: onlyDiscontinued } } })
    * ```
    *
    * @see isNull for the inverse of this test
    */
-  isNotNull?: true;
+  isNotNull?: boolean;
 
   /**
    * Test whether an expression is NULL. By the SQL standard,
@@ -168,11 +171,14 @@ export interface FilterOperators<TValue> {
    * ```ts
    * // Select cars that have no discontinuedAt date.
    * repository.findMany({ where: { discontinuedAt: { isNull: true } } })
+   *
+   * // `false` inverts the test, so a computed flag reads naturally.
+   * repository.findMany({ where: { discontinuedAt: { isNull: !includeArchived } } })
    * ```
    *
    * @see isNotNull for the inverse of this test
    */
-  isNull?: true;
+  isNull?: boolean;
 
   /**
    * Test whether an expression is between two values. This

--- a/packages/alepha/src/orm/core/providers/DbCacheProvider.ts
+++ b/packages/alepha/src/orm/core/providers/DbCacheProvider.ts
@@ -9,8 +9,24 @@ import { DateTimeProvider } from "alepha/datetime";
  *
  * This is intentionally self-contained (no external cache dependencies)
  * so the ORM module does not force `AlephaCache` on all consumers.
+ *
+ * ### Bounded on purpose
+ *
+ * The key space is not: it is derived from the caller's query, so a query built
+ * from user-controlled pagination or filter values mints a fresh entry per
+ * distinct input. `expiresAt` was only ever consulted inside `get()`, so an
+ * entry written once and never read again was reclaimed by nothing short of a
+ * write to its table — never, for a read-mostly table. Two bounds close that:
+ * expired entries are swept on write, and the map is capped at
+ * {@link MAX_ENTRIES} with oldest-first eviction (insertion order).
  */
 export class DbCacheProvider {
+  /**
+   * Hard cap on retained entries. Sized so an ordinary app never reaches it —
+   * this is a leak backstop, not a tuning knob.
+   */
+  public static readonly MAX_ENTRIES = 5_000;
+
   protected readonly dateTime = $inject(DateTimeProvider);
   protected readonly store = new Map<
     string,
@@ -54,6 +70,30 @@ export class DbCacheProvider {
       value,
       expiresAt: ttl ? this.dateTime.nowMillis() + ttl : undefined,
     });
+    this.evict();
+  }
+
+  /**
+   * Reclaim space: drop everything already expired, then, if still over
+   * budget, the oldest entries until the cap is met. `Map` preserves insertion
+   * order, so `keys()` yields oldest-first.
+   */
+  protected evict(): void {
+    const now = this.dateTime.nowMillis();
+
+    for (const [key, entry] of this.store) {
+      if (entry.expiresAt && now > entry.expiresAt) {
+        this.store.delete(key);
+      }
+    }
+
+    while (this.store.size > DbCacheProvider.MAX_ENTRIES) {
+      const oldest = this.store.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.store.delete(oldest);
+    }
   }
 
   /**

--- a/packages/alepha/src/orm/core/services/QueryManager.ts
+++ b/packages/alepha/src/orm/core/services/QueryManager.ts
@@ -133,7 +133,13 @@ export class QueryManager {
           }
         }
 
-        if (Array.isArray(operator)) {
+        // Only `and` / `or` carry a list of nested CONDITIONS. Any other key is
+        // a column name, and an array under a column name is a VALUE — the
+        // shorthand `PgQueryWhereOperators` documents for an array column
+        // (`{ tags: ["x", "y"] }`). Recursing into it treated each element as a
+        // condition object, so `Object.keys("x")` asked for a column literally
+        // named `0` and the query died with "Column '0' not found".
+        if (Array.isArray(operator) && (key === "and" || key === "or")) {
           const operations: SQL[] = operator
             .map((it) => {
               if (isSQLWrapper(it)) {
@@ -151,21 +157,12 @@ export class QueryManager {
           // Combine with the sibling conditions instead of returning early —
           // an early return here silently DROPPED every other key of the
           // where (e.g. `{ userId: {...}, or: [...] }` matched ALL users).
-          if (key === "and") {
-            const combined = and(...operations);
-            if (combined) {
-              conditions.push(combined);
-            }
-            continue;
+          const combined =
+            key === "and" ? and(...operations) : or(...operations);
+          if (combined) {
+            conditions.push(combined);
           }
-
-          if (key === "or") {
-            const combined = or(...operations);
-            if (combined) {
-              conditions.push(combined);
-            }
-            continue;
-          }
+          continue;
         }
 
         if (key === "not") {
@@ -402,12 +399,16 @@ export class QueryManager {
       conditions.push(notInArray(column, encodeArray(operator.notInArray)));
     }
 
+    // Presence is NOT the signal — the VALUE is. `!= null` made
+    // `{ isNull: false }` emit `IS NULL`, the exact opposite predicate, because
+    // `false != null` is true. Nothing in the where builder is allowed to mean
+    // the reverse of what it reads as, so both flags now branch on the boolean.
     if (operator?.isNull != null) {
-      conditions.push(isNull(column));
+      conditions.push(operator.isNull ? isNull(column) : isNotNull(column));
     }
 
     if (operator?.isNotNull != null) {
-      conditions.push(isNotNull(column));
+      conditions.push(operator.isNotNull ? isNotNull(column) : isNull(column));
     }
 
     if (operator?.like != null) {

--- a/packages/alepha/src/orm/core/services/Repository.ts
+++ b/packages/alepha/src/orm/core/services/Repository.ts
@@ -468,7 +468,8 @@ export abstract class Repository<T extends TObject> {
   ): Promise<PgStatic<T, R>[]> {
     // Check cache
     if (opts.cache) {
-      const cacheKey = opts.cache.key ?? this.buildCacheKey("findMany", query);
+      const cacheKey =
+        opts.cache.key ?? this.buildCacheKey("findMany", query, opts);
       const cached = await this.dbCache.get<PgStatic<T, R>[]>(
         this.tableName,
         cacheKey,
@@ -605,7 +606,7 @@ export abstract class Repository<T extends TObject> {
       // Store in cache
       if (opts.cache) {
         const cacheKey =
-          opts.cache.key ?? this.buildCacheKey("findMany", query);
+          opts.cache.key ?? this.buildCacheKey("findMany", query, opts);
         await this.dbCache.set(
           this.tableName,
           cacheKey,
@@ -961,7 +962,10 @@ export abstract class Repository<T extends TObject> {
 
     let setData: any;
     if (opts.set) {
-      setData = opts.set;
+      // Copy, never stamp in place: `updatedAt` is injected below, and writing
+      // it into the caller's `set` object leaves them holding a clause that
+      // gained a column they never wrote. The `else` branch already copies.
+      setData = { ...(opts.set as Record<string, unknown>) };
     } else {
       // Default: update all fields from the insert data except the conflict target and primary key columns
       setData = { ...data };
@@ -1071,12 +1075,16 @@ export abstract class Repository<T extends TObject> {
       data,
     });
 
-    let row = data as any;
-
     const updatedAtField = getAttrFields(
       this.entity.schema,
       PG_UPDATED_AT,
     )?.[0];
+
+    // Shallow-copy before stamping, same as `updateMany`: writing `updatedAt`
+    // into the caller's object hands back a patch carrying a column it never
+    // declared — which bites when the patch is a shared constant, is reused
+    // across calls, or is validated/audited by the caller afterwards.
+    let row: any = { ...(data as Record<string, unknown>) };
 
     if (updatedAtField) {
       row[updatedAtField.key] =
@@ -1350,13 +1358,18 @@ export abstract class Repository<T extends TObject> {
 
     const deletedAt = this.deletedAt();
     if (deletedAt && !opts.force) {
-      // Stamping the caller's entity is DELIBERATE, not a stray mutation: it
+      // Stamping the caller's ENTITY is DELIBERATE, not a stray mutation: it
       // keeps the in-memory object consistent with the row, so a later
       // `save(entity, { force: true })` writes the soft-delete back instead of
       // nulling it and resurrecting the row (`save` nulls undefined fields).
       // `testNoUpdateIfAlreadyDeleted` depends on exactly this.
-      opts.now ??= this.dateTimeProvider.nowISOString();
-      (entity as any)[deletedAt.key] = opts.now;
+      //
+      // The caller's OPTIONS object is a different matter — it belongs to them,
+      // and a reused `StatementOptions` that silently acquired a `now` would
+      // pin every later statement to this instant. Resolve into a local copy.
+      const now = opts.now ?? this.dateTimeProvider.nowISOString();
+      (entity as any)[deletedAt.key] = now;
+      return await this.deleteById(id, { ...opts, now });
     }
 
     return await this.deleteById(id, opts);
@@ -2021,10 +2034,29 @@ export abstract class Repository<T extends TObject> {
   }
 
   /**
-   * Build a cache key from method name and query parameters.
+   * Build a cache key from the method name, the caller's query, AND the
+   * predicate this repository adds on top of it.
+   *
+   * The scope suffix is what makes `opts.cache` safe. Keyed on the caller's
+   * query alone, two tenants issuing the identical `findMany` shared one entry
+   * and whichever arrived first filled it for everyone — a cross-tenant read
+   * caused by nothing but switching on a performance flag. The same omission
+   * let a `force: true` read (which deliberately includes soft-deleted rows)
+   * poison the entry a normal read then consumed.
+   *
+   * `readWhere()` is exactly the org + soft-delete envelope applied to the
+   * statement, so folding it in keeps one cache entry per (query, tenant,
+   * visibility) triple. It also throws on strict tenancy with no tenant
+   * resolved, which is the correct answer on a cached read too — the entry
+   * must not be reachable without a tenant when the query itself would not be.
    */
-  protected buildCacheKey(method: string, query: any): string {
-    return `${method}:${JSON.stringify(query)}`;
+  protected buildCacheKey(
+    method: string,
+    query: any,
+    opts: StatementOptions = {},
+  ): string {
+    const scope = JSON.stringify(this.readWhere(query?.where ?? {}, opts));
+    return `${method}:${JSON.stringify(query)}:${scope}`;
   }
 
   /**

--- a/packages/alepha/src/security/__tests__/$owns-primary-key.spec.ts
+++ b/packages/alepha/src/security/__tests__/$owns-primary-key.spec.ts
@@ -1,0 +1,102 @@
+import { $inject, $pipeline, Alepha, z } from "alepha";
+import { $entity, $repository, db } from "alepha/orm";
+import { ForbiddenError } from "alepha/server";
+import { describe, expect, it } from "vitest";
+import { currentUserAtom } from "../atoms/currentUserAtom.ts";
+import type { UserAccountToken } from "../interfaces/UserAccountToken.ts";
+import { $owns } from "../primitives/$owns.ts";
+import { OwnedResourceProvider } from "../providers/OwnedResourceProvider.ts";
+
+/**
+ * `$owns` accepts any repository, so it must resolve the primary key the way
+ * the repository does — not assume the column is called `id`.
+ */
+
+const docs = $entity({
+  name: "owns_pk_docs",
+  schema: z.object({
+    docId: db.primaryKey(z.text()),
+    createdBy: z.text(),
+    title: z.text(),
+  }),
+});
+
+const counters = $entity({
+  name: "owns_pk_counters",
+  schema: z.object({
+    counterId: db.primaryKey(z.integer()),
+    createdBy: z.text(),
+  }),
+});
+
+const owner: UserAccountToken = { id: "u1", realm: "default", roles: [] };
+const stranger: UserAccountToken = { id: "u2", realm: "default", roles: [] };
+
+class Service {
+  docs = $repository(docs);
+  counters = $repository(counters);
+  owned = $inject(OwnedResourceProvider);
+
+  readDoc = $pipeline({
+    use: [
+      $owns({ repository: () => this.docs, param: "id", owner: "createdBy" }),
+    ],
+    handler: async () => this.owned.get<{ title: string }>().title,
+  });
+
+  readCounter = $pipeline({
+    use: [
+      $owns({
+        repository: () => this.counters,
+        param: "id",
+        owner: "createdBy",
+      }),
+    ],
+    handler: async () => "ok",
+  });
+}
+
+const boot = async () => {
+  const alepha = Alepha.create({ env: { DATABASE_URL: "sqlite://:memory:" } });
+  const svc = alepha.inject(Service);
+  await alepha.start();
+  await svc.docs.create({ docId: "d1", createdBy: "u1", title: "hello" });
+  await svc.counters.create({ createdBy: "u1" });
+  return { alepha, svc };
+};
+
+const as = <R>(
+  alepha: Alepha,
+  user: UserAccountToken,
+  id: string,
+  fn: () => Promise<R>,
+) =>
+  alepha.context.run(() => {
+    alepha.store.set(currentUserAtom, user);
+    // biome-ignore lint/suspicious/noExplicitAny: minimal request stub
+    alepha.store.set("alepha.action.request", {
+      params: { id },
+      query: {},
+    } as any);
+    return fn();
+  });
+
+describe("$owns resolves the entity's own primary key", () => {
+  it("should load a resource whose primary key is not named 'id'", async () => {
+    const { alepha, svc } = await boot();
+    expect(await as(alepha, owner, "d1", () => svc.readDoc())).toBe("hello");
+  });
+
+  it("should still deny a non-owner", async () => {
+    const { alepha, svc } = await boot();
+    await expect(
+      as(alepha, stranger, "d1", () => svc.readDoc()),
+    ).rejects.toThrow(ForbiddenError);
+  });
+
+  it("should coerce the route param to a numeric primary key", async () => {
+    const { alepha, svc } = await boot();
+    // No `cast` declared: the repository knows the key is an integer.
+    expect(await as(alepha, owner, "1", () => svc.readCounter())).toBe("ok");
+  });
+});

--- a/packages/alepha/src/security/__tests__/$secure-guard-context.spec.ts
+++ b/packages/alepha/src/security/__tests__/$secure-guard-context.spec.ts
@@ -1,0 +1,128 @@
+import { $pipeline, Alepha, z } from "alepha";
+import { $entity, $repository, db } from "alepha/orm";
+import { describe, expect, it } from "vitest";
+import { currentUserAtom } from "../atoms/currentUserAtom.ts";
+import { $owns, $secure } from "../index.ts";
+
+/**
+ * A `$secure` guard runs real code — `$owns` loads a row through a repository.
+ * Anything it calls must see the authenticated identity, otherwise
+ * tenant-scoped reads inside the guard resolve no tenant: a non-strict entity
+ * is read unscoped, and a strict one refuses outright.
+ *
+ * The user therefore has to be published to the store BEFORE the guard runs,
+ * not after — and the behaviour must not differ between transports.
+ */
+
+const ORG = "11111111-1111-1111-1111-111111111111";
+
+const docs = $entity({
+  name: "guard_ctx_docs",
+  schema: z.object({
+    id: db.primaryKey(z.text()),
+    organization: db.organization({ strict: true }),
+    createdBy: z.text(),
+    title: z.text(),
+  }),
+});
+
+const USER = {
+  id: "u1",
+  realm: "default",
+  roles: [] as string[],
+  organization: ORG,
+};
+
+class Service {
+  docs = $repository(docs);
+
+  read = $pipeline({
+    use: [
+      $owns({ repository: () => this.docs, param: "id", owner: "createdBy" }),
+    ],
+    handler: async () => "ok",
+  });
+}
+
+const boot = async () => {
+  const alepha = Alepha.create({ env: { DATABASE_URL: "sqlite://:memory:" } });
+  const svc = alepha.inject(Service);
+  await alepha.start();
+
+  await alepha.context.run(async () => {
+    alepha.store.set(currentUserAtom, USER);
+    await svc.docs.create({ id: "d1", createdBy: "u1", title: "t" });
+  });
+
+  return { alepha, svc };
+};
+
+describe("$secure publishes the user before running the guard", () => {
+  it("should expose the user to the guard when it arrived on the HTTP request", async () => {
+    const alepha = Alepha.create();
+    const seen: Array<string> = [];
+
+    class App {
+      fn = $pipeline({
+        use: [
+          $secure({
+            guard: () => {
+              seen.push(
+                alepha.store.get(currentUserAtom) ? "present" : "missing",
+              );
+              return true;
+            },
+          }),
+        ],
+        handler: async () => "ok",
+      });
+    }
+
+    const app = alepha.inject(App);
+    await alepha.start();
+
+    await alepha.context.run(async () => {
+      alepha.store.set("alepha.http.request", {
+        user: USER,
+        params: {},
+        query: {},
+        // biome-ignore lint/suspicious/noExplicitAny: minimal request stub
+      } as any);
+      await app.fn();
+    });
+
+    expect(seen).toEqual(["present"]);
+  });
+
+  it("should let $owns read a strict tenant entity over HTTP", async () => {
+    const { alepha, svc } = await boot();
+
+    const result = await alepha.context.run(async () => {
+      alepha.store.set("alepha.http.request", {
+        user: USER,
+        params: { id: "d1" },
+        query: {},
+        // biome-ignore lint/suspicious/noExplicitAny: minimal request stub
+      } as any);
+      return svc.read();
+    });
+
+    expect(result).toBe("ok");
+  });
+
+  it("should behave identically when the user arrives through the atom", async () => {
+    const { alepha, svc } = await boot();
+
+    const result = await alepha.context.run(async () => {
+      alepha.store.set(currentUserAtom, USER);
+      alepha.store.set("alepha.action.request", {
+        params: { id: "d1" },
+        query: {},
+        // biome-ignore lint/suspicious/noExplicitAny: minimal request stub
+      } as any);
+      return svc.read();
+    });
+
+    expect(result).toBe("ok");
+  });
+});

--- a/packages/alepha/src/security/__tests__/$secure-ownership.spec.ts
+++ b/packages/alepha/src/security/__tests__/$secure-ownership.spec.ts
@@ -1,0 +1,70 @@
+import { $pipeline, Alepha } from "alepha";
+import { describe, expect, it } from "vitest";
+import { currentUserAtom } from "../atoms/currentUserAtom.ts";
+import { $role, $secure } from "../index.ts";
+
+/**
+ * `permissions` is an AND list. Each entry can narrow the grant to rows the
+ * caller owns (`ownership: true`), and `$owns` treats `ownership === false` as
+ * a full bypass of its row check. Combining them must therefore take the MOST
+ * RESTRICTIVE answer — and must not depend on the order they were listed in.
+ */
+
+class Roles {
+  editor = $role({
+    name: "editor",
+    permissions: [
+      { name: "docs:read", ownership: true }, // own rows only
+      { name: "docs:list" }, // every row
+    ],
+  });
+}
+
+const ownershipFor = async (permissions: string[]) => {
+  const alepha = Alepha.create();
+
+  class App {
+    fn = $pipeline({
+      use: [$secure({ permissions })],
+      handler: async () => alepha.store.get(currentUserAtom)?.ownership,
+    });
+  }
+
+  alepha.inject(Roles);
+  const app = alepha.inject(App);
+  await alepha.start();
+
+  const result = await alepha.context.run(async () => {
+    alepha.store.set(currentUserAtom, {
+      id: "u1",
+      realm: "default",
+      roles: ["editor"],
+    });
+    return app.fn();
+  });
+
+  await alepha.stop();
+  return result;
+};
+
+describe("$secure permission ownership", () => {
+  it("should not depend on the order permissions are listed in", async () => {
+    const readFirst = await ownershipFor(["docs:read", "docs:list"]);
+    const listFirst = await ownershipFor(["docs:list", "docs:read"]);
+
+    expect(readFirst).toEqual(listFirst);
+  });
+
+  it("should keep the owner-scoped restriction when any permission requires it", async () => {
+    expect(await ownershipFor(["docs:read", "docs:list"])).toBe(true);
+    expect(await ownershipFor(["docs:list", "docs:read"])).toBe(true);
+  });
+
+  it("should stay unrestricted when no permission requires ownership", async () => {
+    expect(await ownershipFor(["docs:list"])).toBe(false);
+  });
+
+  it("should stay owner-scoped for a single owner-scoped permission", async () => {
+    expect(await ownershipFor(["docs:read"])).toBe(true);
+  });
+});

--- a/packages/alepha/src/security/primitives/$owns.ts
+++ b/packages/alepha/src/security/primitives/$owns.ts
@@ -72,9 +72,11 @@ export function $owns(options: OwnsOptions): Middleware {
 
       const repository = options.repository();
       const id = options.cast ? options.cast(raw) : raw;
-      const row = await repository.findOne({
-        where: { id: { eq: id } } as any,
-      });
+      // `findById` resolves the entity's OWN primary-key column (and coerces
+      // the raw param to its declared type). Hardcoding `{ id: { eq } }` here
+      // crashed with "Column 'id' not found" on every entity whose key is
+      // named anything else — at runtime only, since the where was cast away.
+      const row = await repository.findById(id as string | number);
 
       if (!row) {
         throw new NotFoundError(`${repository.tableName} '${raw}' not found`);
@@ -166,8 +168,14 @@ export interface OwnsOptions {
   };
 
   /**
-   * Coerce the raw string route param before querying — e.g. `Number` for
-   * integer primary keys.
+   * Coerce the raw string route param before querying.
+   *
+   * Rarely needed: the resource lookup goes through `findById`, which already
+   * coerces the value to the primary key's declared type, so an integer key
+   * works without a `cast: Number`. Reach for it when the param needs a
+   * transformation the schema cannot express (decoding a slug, say).
+   *
+   * The `via` membership lookup receives the same coerced value.
    */
   cast?: (raw: string) => unknown;
 

--- a/packages/alepha/src/security/primitives/$secure.ts
+++ b/packages/alepha/src/security/primitives/$secure.ts
@@ -108,6 +108,14 @@ export interface SecureGuardContext {
  *
  * Permissions declared in `$secure()` are auto-created in the permission registry at definition time.
  *
+ * Because `permissions` is an AND list, the resulting `ownership` is the most
+ * restrictive of the matched grants — one owner-scoped permission narrows the
+ * whole call, whatever order the list was written in.
+ *
+ * The resolved user is published to `currentUserAtom` and to the request
+ * **before** the guard runs, so anything the guard calls (a repository read in
+ * `$owns`, for instance) resolves the same tenant the handler would.
+ *
  * ## Browser Behavior
  *
  * On the server, `$secure` throws `UnauthorizedError` or `ForbiddenError`.
@@ -197,7 +205,16 @@ export function $secure(options?: SecureOptions): Middleware {
 
         // 6. Explicit permission checks (all must pass) — role names are
         // resolved within the user's own realm, never across realms.
+        //
+        // `permissions` is an AND list, so the resulting `ownership` must be
+        // the MOST RESTRICTIVE of the answers, not the last one. Overwriting
+        // per iteration made the outcome depend on the order the caller listed
+        // them in: with one owner-scoped grant and one unrestricted grant,
+        // putting the unrestricted one last yielded `ownership: false`, which
+        // `$owns` reads as a full bypass of its row check.
         if (options?.permissions?.length) {
+          let ownership: string | boolean | undefined;
+
           for (const perm of options.permissions) {
             const result = securityProvider.checkPermissionInRealm(
               user.realm,
@@ -209,38 +226,33 @@ export function $secure(options?: SecureOptions): Middleware {
                 `Permission '${typeof perm === "string" ? perm : perm.name}' required`,
               );
             }
-            user = { ...user, ownership: result.ownership };
+
+            // A truthy ownership narrows the grant to rows the caller owns and
+            // always wins. `false` (unrestricted) only fills in a slot nothing
+            // has narrowed yet, and `undefined` never overwrites a decision.
+            if (result.ownership) {
+              ownership = result.ownership;
+            } else if (ownership === undefined) {
+              ownership = result.ownership;
+            }
           }
+
+          user = { ...user, ownership };
         }
 
-        // 7. Custom guard — the only check with request visibility.
+        // 7. Publish the resolved user BEFORE the guard runs.
         //
-        // Awaited: before this was async, returning a promise from a guard
-        // made the truthiness check always pass, so an async guard silently
-        // allowed everyone through.
-        if (options?.guard) {
-          const httpRequest = alepha.store.get("alepha.http.request");
-          const actionRequest = alepha.store.get(
-            "alepha.action.request",
-            "current",
-          );
-          const source: any = actionRequest ?? httpRequest;
-
-          const allowed = await options.guard({
-            user,
-            params: source?.params ?? {},
-            query: source?.query ?? {},
-            body: source?.body,
-            request: httpRequest,
-            alepha,
-          });
-
-          if (!allowed) {
-            throw new ForbiddenError("Access denied");
-          }
-        }
-
-        // 8. Store user in atom and requests
+        // A guard runs real code — `$owns` loads a row through a repository —
+        // and `Repository.resolveOrganizationValue()` reads `currentUserAtom`.
+        // Publishing afterwards meant every guard on the HTTP path (where
+        // `$secure` itself resolved the user from headers) queried with no
+        // tenant in context: a non-strict entity was read unscoped, and a
+        // strict one refused outright with a 500. Over `action.run()` / MCP the
+        // atom was already populated by the caller, so the two transports
+        // disagreed on the same route.
+        //
+        // Denial still aborts before `next()`, so a published-then-rejected
+        // user is never observable by the handler.
         securityProvider.storeUserInContext(user);
 
         const httpRequest = alepha.store.get("alepha.http.request", "current");
@@ -254,6 +266,32 @@ export function $secure(options?: SecureOptions): Middleware {
         );
         if (actionRequest) {
           actionRequest.user = user;
+        }
+
+        // 8. Custom guard — the only check with request visibility.
+        //
+        // Awaited: before this was async, returning a promise from a guard
+        // made the truthiness check always pass, so an async guard silently
+        // allowed everyone through.
+        if (options?.guard) {
+          // Resolved without the `"current"` scope: `$secure` may run inside a
+          // nested fork, and the HTTP request lives on an ancestor layer.
+          const request = alepha.store.get("alepha.http.request");
+          const source: any =
+            alepha.store.get("alepha.action.request", "current") ?? request;
+
+          const allowed = await options.guard({
+            user,
+            params: source?.params ?? {},
+            query: source?.query ?? {},
+            body: source?.body,
+            request,
+            alepha,
+          });
+
+          if (!allowed) {
+            throw new ForbiddenError("Access denied");
+          }
         }
 
         return next(...args);

--- a/packages/alepha/src/server/rate-limit/__tests__/counter-expiry.spec.ts
+++ b/packages/alepha/src/server/rate-limit/__tests__/counter-expiry.spec.ts
@@ -1,0 +1,89 @@
+import { Alepha } from "alepha";
+import { AlephaCache, CacheProvider, MemoryCacheProvider } from "alepha/cache";
+import { DateTimeProvider } from "alepha/datetime";
+import { describe, expect, it } from "vitest";
+import { ServerRateLimitProvider } from "../index.ts";
+
+/**
+ * Every counter key embeds its fixed window, so a new key is minted each
+ * window. Without a TTL none of them is ever reclaimed: the memory provider
+ * grows without bound, and Redis/D1 keep a key per (identity, window) forever.
+ * `CacheProvider.incr` documents the requirement — the limiter has to honour it.
+ */
+
+class RecordingCache extends MemoryCacheProvider {
+  public incrCalls: Array<{ key: string; ttl?: number }> = [];
+
+  public override async incr(
+    name: string,
+    key: string,
+    amount: number,
+    ttl?: number,
+  ): Promise<number> {
+    this.incrCalls.push({ key, ttl });
+    return super.incr(name, key, amount, ttl);
+  }
+}
+
+const boot = async () => {
+  const alepha = Alepha.create()
+    // Substituted before the module binds its own default.
+    .with({ provide: CacheProvider, use: RecordingCache })
+    .with(AlephaCache);
+  const provider = alepha.inject(ServerRateLimitProvider);
+  const cache = alepha.inject(RecordingCache);
+  const dateTime = alepha.inject(DateTimeProvider);
+  await alepha.start();
+  return { alepha, provider, cache, dateTime };
+};
+
+describe("rate-limit counters expire", () => {
+  it("should arm a TTL on every counter it writes", async () => {
+    const { provider, cache } = await boot();
+
+    await provider.checkLimitByKey("ip:1.2.3.4", { max: 5, windowMs: 60_000 });
+
+    expect(cache.incrCalls).toHaveLength(1);
+    expect(cache.incrCalls[0].ttl).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it("should not retain a previous window's counter", async () => {
+    const { provider, cache, dateTime } = await boot();
+    dateTime.pause();
+
+    await provider.checkLimitByKey("ip:1.2.3.4", { max: 5, windowMs: 60_000 });
+    const firstKey = cache.incrCalls[0].key;
+
+    dateTime.travel(3_600_000);
+    await provider.checkLimitByKey("ip:1.2.3.4", { max: 5, windowMs: 60_000 });
+
+    expect(cache.incrCalls[1].key).not.toBe(firstKey);
+    expect(await cache.has("rate-limit", firstKey)).toBe(false);
+  });
+
+  it("should arm a TTL on a refund too", async () => {
+    const { provider, cache } = await boot();
+
+    const result = await provider.checkLimitByKey("ip:5.6.7.8", {
+      max: 5,
+      windowMs: 60_000,
+    });
+    await provider.refund(
+      result,
+      { max: 5, windowMs: 60_000, skipSuccessfulRequests: true },
+      { failed: false },
+    );
+
+    expect(cache.incrCalls).toHaveLength(2);
+    expect(cache.incrCalls[1].ttl).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it("should still count and block within a window", async () => {
+    const { provider } = await boot();
+
+    const opts = { max: 2, windowMs: 60_000 };
+    expect((await provider.checkLimitByKey("ip:9", opts)).allowed).toBe(true);
+    expect((await provider.checkLimitByKey("ip:9", opts)).allowed).toBe(true);
+    expect((await provider.checkLimitByKey("ip:9", opts)).allowed).toBe(false);
+  });
+});

--- a/packages/alepha/src/server/rate-limit/providers/ServerRateLimitProvider.ts
+++ b/packages/alepha/src/server/rate-limit/providers/ServerRateLimitProvider.ts
@@ -27,6 +27,15 @@ export interface RateLimitResult {
    * refund the wrong bucket.
    */
   key: string;
+
+  /**
+   * Counter lifetime (ms) armed for {@link key}.
+   *
+   * Carried on the result for the same reason as `key`: a refund must re-arm
+   * the identical TTL rather than recompute one from options that may resolve
+   * differently, and a counter written with no TTL is never reclaimed.
+   */
+  ttl: number;
 }
 
 /**
@@ -214,10 +223,15 @@ export class ServerRateLimitProvider {
     }
 
     try {
+      // Same TTL the check armed. A refund can land after the counter expired
+      // (the response settles after the window rolled), which re-creates the
+      // key — without a TTL that recreated key would then live forever, which
+      // is the exact leak the check-side TTL closes.
       await this.cacheProvider.incr(
         ServerRateLimitProvider.CACHE_NAME,
         result.key,
         -1,
+        result.ttl,
       );
     } catch (error) {
       this.log.warn("Failed to refund a rate-limit counter", error);
@@ -243,11 +257,25 @@ export class ServerRateLimitProvider {
     // Include window timestamp in key for automatic expiration of old windows
     const key = `${baseKey}:${windowStart}`;
 
+    // A per-window key means the counter is never READ again once the window
+    // rolls — but without a TTL it is never RECLAIMED either, so every
+    // (identity, window) pair left a key behind forever: an unbounded heap in
+    // the memory provider, an unbounded keyspace in Redis/D1. `incr`'s own
+    // contract calls this out.
+    //
+    // Two windows, not one: the counter must comfortably outlive the window it
+    // counts (it is armed on creation and never extended, so a one-window TTL
+    // would expire mid-window for a counter created near the boundary), and a
+    // refund settles after the response. One extra window of garbage-collection
+    // lag costs nothing — the key is unreachable the moment its window ends.
+    const ttl = windowMs * 2;
+
     // Atomic increment - returns the new count after incrementing
     const count = await this.cacheProvider.incr(
       ServerRateLimitProvider.CACHE_NAME,
       key,
       1,
+      ttl,
     );
 
     const allowed = count <= max;
@@ -259,6 +287,7 @@ export class ServerRateLimitProvider {
       remaining,
       resetTime,
       key,
+      ttl,
     };
 
     if (!allowed) {


### PR DESCRIPTION
Ten defects found during a full review of `alepha` and `@alepha/*`, all fixed. The review that produced them is in `assets/docs/BUGS.md` (untracked, local only) alongside a feature inventory in `assets/docs/FEATURES.md`.

**Every finding was reproduced with a test that was watched failing, for the right reason, before any fix was written.** Eight new spec files, 33 tests. Two candidates that looked wrong on reading were falsified and are listed at the bottom so nobody re-investigates them.

---

## The two that matter

**Cross-tenant read through the query cache** (critical). `findMany(query, { cache })` keyed the entry on the caller's query alone. The tenant predicate is one the repository *adds* — applied after the cache lookup, so never part of the key. Two organizations issuing the same query shared one entry; the first to arrive filled it for everyone.

```ts
const a = await asOrg(ORG_A, () => docs.findMany({ orderBy: "id" }, { cache: { ttl: 60_000 } }));
const b = await asOrg(ORG_B, () => docs.findMany({ orderBy: "id" }, { cache: { ttl: 60_000 } }));
// before:  orgA=["secret-A"]  orgB=["secret-A"]
```

`db.organization()` exists so tenancy is not remembered at each call site. Turning on `{ cache }` — a performance knob whose JSDoc warned of nothing — silently defeated it.

**Authorization that depended on array order** (high). `$secure({ permissions })` overwrote `ownership` on every loop iteration, so the effective value was whichever permission came **last**. `$owns` reads `ownership === false` as a total bypass of its row check.

```ts
ownershipFor(["docs:read", "docs:list"])  // → false   (bypass)
ownershipFor(["docs:list", "docs:read"])  // → true    (enforced)
```

Same user, same role, same permission set. Listing a broad permission last silently disabled row-level authorization on that route.

## The rest

| Area | Defect |
|---|---|
| orm | `{ isNull: false }` emitted `IS NULL`, `{ isNotNull: false }` emitted `IS NOT NULL` — `!= null` tested presence, never value |
| orm | `opts.force` absent from the cache key, so a `force: true` read served soft-deleted rows to a normal read |
| orm | `{ tags: ["x","y"] }` — the documented array shorthand — recursed as an `and`/`or` list and died with `Column '0' not found` |
| orm | `updateOne` / `updateById` / `upsert` stamped `updatedAt` into the caller's object (`updateMany` already copied) |
| orm | `DbCacheProvider` was an unbounded `Map` whose expiry was only consulted on read |
| security | `$secure` published the user to `currentUserAtom` **after** running the guard, so `$owns` on a tenant-scoped entity resolved no tenant — unscoped read, or a 500 on a `strict` entity |
| security | `$owns` hardcoded `id` as the primary-key column |
| server | Rate-limit counters written with no TTL — one key per (identity, window), never reclaimed |

Two of these only bit one transport. The `$secure` guard ordering broke over HTTP (where `$secure` itself resolves the user from headers) but worked over `action.run()` / MCP, where the caller had already populated the atom — the same route behaving differently depending on how it was reached, which is why the suite never caught it.

---

## ⚠️ One deliberate behaviour change

`$secure` now takes the **most restrictive** ownership across a permission list, instead of the last one. This is **stricter than before**: a route that leaned on the old behaviour — knowingly or not — now enforces `$owns`.

The full suite passes unchanged, Lore's e2e included (53 tests covering auth, petitions, invitations). It is still the one change here worth a second look, and the reason this is a PR rather than a merge.

Not marked `!`: the API surface is unchanged and the shift is strictly fail-safe. Say the word if you want a `BREAKING CHANGE:` footer instead.

---

## CI

Second commit, separable. CI triggered on `push` to `main` and nothing else, which made the only CI run that ever happens the same event that deploys Lore to production — a branch could not be proven green without shipping it, and a PR carried no signal at all. Adds a `pull_request` trigger.

`deploy-docs` had to be guarded for that to be safe: it carried no event condition, only `needs: [checks, test]`, so it would have published to GitHub Pages on every PR. `deploy-lore-production` was already guarded and is untouched.

**This PR is the first run of that trigger** — the checks below are the proof it works.

---

## Verification

Baseline before any change: 471 files / 5028 tests green. After: **479 files / 5061 tests green.**

`yarn lint` · `yarn typecheck` (all workspaces, sequential) · `yarn test` · `yarn build` (catches circular deps) · `check:deps` / `check:i18n` / `check:migrations` · `yarn e2e` (docs, example-ssr, playground, lore).

Based on `origin/main` @ `a9d4ccd44`. None of the touched files changed between that and the older commit the review was written against, so every finding holds verbatim.

## Falsified — not bugs

Recorded so they are not re-opened: join-aware `paginate` counts (LEFT JOINs make the base count correct), `QueryCache` leaking across SSR requests (ALS forks isolate it), `$memoize` FIFO eviction (re-`set` preserves `Map` order), `ServerStaticProvider` path traversal (files enumerated at boot, no request path reaches the FS), `Math.random()` in `UsernameSlugger` / `SessionService` (never used for a secret).
