### PR TITLE
Bay: survive twenty apps on one host

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,8 @@ LOG_FORMAT=pretty LOG_LEVEL=trace yarn w @alepha/devtools build
 ## Development Commands
 
 ### Core Commands
-- `yarn v` or `yarn alepha verify` - Full verification pipeline: clean, lint, typecheck, test, check:deps, check:i18n, check:migrations, build, e2e, clean. **Must complete within 5 minutes** — always run it with a 5-minute timeout. If it exceeds 5 minutes, treat that as a failure (a hung step, usually e2e) and investigate, do not just wait longer.
+- `yarn v` or `yarn alepha verify` - Full verification pipeline: clean, lint, typecheck, test, check:deps, check:i18n, check:migrations, Bay's Go suite on Linux, build, e2e, clean. **Must complete within 10 minutes** — always run it with a 10-minute timeout. If it exceeds 10 minutes, treat that as a failure (a hung step, usually e2e) and investigate, do not just wait longer. Raised from 5 when Bay joined the pipeline: `test:linux` starts a container, and the repo now verifies a Go binary as well as the JS workspace.
+  - **Needs Docker running.** Already true for the service checks (postgres, redis, s3mock, emqx), and now also for `yarn w bay test:linux`.
 - `yarn v --fast` - Inner-loop sanity check: lint + (typecheck, test, test:bun, check:deps, check:i18n, check:migrations) in parallel. Skips clean/copy/build/e2e. Use for tight iteration.
 - `yarn clean` or `yarn alepha clean` - Remove all generated files and node_modules
 - `yarn build` - Build all workspace packages using `tsdown`

--- a/alepha.config.ts
+++ b/alepha.config.ts
@@ -112,6 +112,11 @@ export default (alepha: Alepha) => {
             `yarn check:docs`,
             `yarn check:i18n`,
             `yarn check:migrations`,
+            // The native Go pass, ~4s. Partial by construction: on macOS,
+            // `internal/runner/systemd_test.go` is `//go:build linux`, so 7 of
+            // that package's 12 tests are not compiled and `ok` is printed
+            // anyway. The full pass runs in a container below, out of --fast.
+            `yarn w bay test`,
           ]);
           await assertServicesUp();
           await run([`yarn test`, `yarn test:bun`]);
@@ -126,6 +131,19 @@ export default (alepha: Alepha) => {
         await run(`yarn check:deps`);
         await run(`yarn typecheck`);
         await assertServicesUp();
+
+        // Bay's suite, on the platform it ships for. ~18s in a container.
+        //
+        // A superset of `yarn w bay test`, not a repeat of it: gofmt, vet,
+        // build, the whole test suite and a cross-compile for both Linux
+        // architectures — the same steps as the `bay` CI job. It is here rather
+        // than in --fast because it costs a container start, and it is here at
+        // all because a native `go test` is GREEN while skipping every test of
+        // `Systemd.render()`: the sandbox directives, the memory and CPU
+        // ceilings, the stop timeout. Those files are `//go:build linux` and do
+        // not exist on the machine this is usually run from.
+        await run(`yarn w bay test:linux`);
+
         await run(`yarn test`);
         await run(`yarn test:bun`);
         await run(`yarn check:i18n`);

--- a/apps/bay-admin/src/api/schemas/bayAppSchema.ts
+++ b/apps/bay-admin/src/api/schemas/bayAppSchema.ts
@@ -29,6 +29,20 @@ export const bayAppSchema = z.object({
    * Optional throughout, because bay-go reports nothing rather than zero when
    * it does not know. A zero would read as a measurement.
    */
+  /**
+   * When this app last answered a request, RFC3339. Absent means never.
+   *
+   * Declared here for the same reason `usage` is: the response schema is what
+   * serializes, so a field it does not name is dropped on the way out with no
+   * error anywhere — the browser simply receives nothing.
+   */
+  lastRequestAt: z.text().optional(),
+  /**
+   * How many crons the deployed artifact declared. Absent on an older bay-go,
+   * which must read as "unknown" rather than "none": telling someone an app has
+   * no scheduled work when it has three is how a working app gets deleted.
+   */
+  crons: z.integer().optional(),
   usage: z
     .object({
       memoryBytes: z.integer().optional(),

--- a/apps/bay-admin/src/api/services/BayControlService.ts
+++ b/apps/bay-admin/src/api/services/BayControlService.ts
@@ -32,6 +32,28 @@ export interface BayApp {
   backups?: boolean;
   lastBackupAt?: string;
   lastBackupError?: string;
+  /**
+   * When this app last ANSWERED a request, RFC3339. Absent means never.
+   *
+   * Recorded by Bay's proxy, not reported by the app: the proxy serves static
+   * files and prerendered HTML itself, so a page someone reads every morning
+   * can reach the app process zero times. Asking the app would call it idle.
+   *
+   * Requests the app refused do not count. Every Bay domain is public the
+   * moment its certificate is issued — Let's Encrypt publishes them all to the
+   * Certificate Transparency logs — so a prototype nobody has ever shared
+   * still collects scanner traffic forever. Counting that would show every
+   * abandoned app as freshly used.
+   */
+  lastRequestAt?: string;
+  /**
+   * How many cron expressions the deployed artifact declared.
+   *
+   * The correction to reading `lastRequestAt` alone: an app whose whole job is
+   * a weekly email serves nobody and looks abandoned. This is what stops it
+   * being deleted.
+   */
+  crons?: number;
 }
 
 /**

--- a/apps/bay-admin/src/web/components/AppList.tsx
+++ b/apps/bay-admin/src/web/components/AppList.tsx
@@ -26,6 +26,7 @@ import type {
   BayApp,
   BayAppUsage,
 } from "../../api/services/BayControlService.ts";
+import { quietLabel } from "./quietLabel.ts";
 
 export interface AppListProps {
   apps: BayApp[];
@@ -183,6 +184,19 @@ const AppList = (props: AppListProps) => {
                     <Badge variant="destructive">
                       {app.usage?.restarts}× restarted
                     </Badge>
+                  )}
+                  {/*
+                    The deletion-triage badge, and the only one here that is not
+                    about health. With twenty prototypes on one host the question
+                    stops being "is this broken" and becomes "is anyone still
+                    using this".
+
+                    Not destructive: quiet is not a fault. An app can be quiet
+                    for a year and be exactly what someone wants next month —
+                    this is an invitation to ask, not a defect to fix.
+                  */}
+                  {quietLabel(app, dt) && (
+                    <Badge variant="outline">{quietLabel(app, dt)}</Badge>
                   )}
                 </div>
                 <a

--- a/apps/bay-admin/src/web/components/quietLabel.ts
+++ b/apps/bay-admin/src/web/components/quietLabel.ts
@@ -1,0 +1,65 @@
+import type { DateTimeProvider } from "alepha/datetime";
+import type { BayApp } from "../../api/services/BayControlService.ts";
+
+/**
+ * How long an app must go unused before saying so is useful rather than noisy.
+ *
+ * Thirty days, not seven. A prototype nobody touched for a week is normal — a
+ * holiday, a sprint spent elsewhere, a demo that runs monthly. A badge that
+ * fires on all of those is one people learn to scroll past, which costs more
+ * than never having shown it at all.
+ */
+export const QUIET_AFTER_DAYS = 30;
+
+/**
+ * Matches a Bay release directory name, `2006-01-02-150405` in UTC.
+ */
+const RELEASE_STAMP = /^(\d{4})-(\d{2})-(\d{2})-(\d{2})(\d{2})(\d{2})/;
+
+/**
+ * Says how long an app has gone unused, or nothing when that is not worth
+ * saying.
+ *
+ * Falls back to the release timestamp when the app has never answered at all.
+ * Without that fallback the two ends of the scale collapse into one: an app
+ * deployed forty seconds ago and an app deployed in March and never once
+ * opened both have no `lastRequestAt`, and only one of them is a candidate for
+ * deletion. Dating the silence from the deploy separates them, and it has the
+ * happy side effect that a fresh deploy is never badged.
+ *
+ * Reports the cron count alongside, when there is one. An app whose entire job
+ * is a weekly mailer answers nobody and would otherwise read as the deadest
+ * thing on the host — this is what stops it being deleted on that reading.
+ */
+export const quietLabel = (
+  app: BayApp,
+  dt: DateTimeProvider,
+): string | undefined => {
+  const since = app.lastRequestAt ?? releaseDate(app.release);
+  if (!since) {
+    return undefined;
+  }
+  if (dt.now().diff(dt.of(since), "day") < QUIET_AFTER_DAYS) {
+    return undefined;
+  }
+  const quiet = `Quiet ${dt.of(since).fromNow(true)}`;
+  // `crons` is absent on an older bay-go, and absent means unknown, not none.
+  // Saying nothing is right: claiming an app has no scheduled work, when
+  // nobody actually asked, is the false reassurance that gets it deleted.
+  if (!app.crons) {
+    return quiet;
+  }
+  return `${quiet} · ${app.crons} cron${app.crons > 1 ? "s" : ""}`;
+};
+
+/**
+ * Turns a release directory name into something parseable.
+ */
+const releaseDate = (release: string | undefined): string | undefined => {
+  const parts = RELEASE_STAMP.exec(release ?? "");
+  if (!parts) {
+    return undefined;
+  }
+  const [, year, month, day, hour, minute, second] = parts;
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}Z`;
+};

--- a/apps/bay-admin/test/bayAppSchema.spec.ts
+++ b/apps/bay-admin/test/bayAppSchema.spec.ts
@@ -50,4 +50,46 @@ describe("bayAppSchema", () => {
     expect(parsed.usage).toBeUndefined();
     expect(parsed.running).toBeUndefined();
   });
+
+  it("should carry the traffic record through to the browser", () => {
+    /*
+      Same trap as `usage`, and the one this file exists for: the response
+      schema is what serializes, so a field it does not name never reaches the
+      browser — no error, no log line, just a badge that is always absent.
+
+      Worse here than for `usage`, because the failure looks like good news. A
+      missing `lastRequestAt` renders as "no badge", which reads as "this app is
+      in use" — so the whole point of the feature inverts silently.
+    */
+    const parsed = bayAppSchema.parse({
+      name: "demo",
+      env: "production",
+      domain: "demo.example.com",
+      release: "2026-07-31-120000",
+      port: 4000,
+      runtime: "node",
+      lastRequestAt: "2026-07-31T09:14:22Z",
+      crons: 3,
+    });
+
+    expect(parsed.lastRequestAt).toBe("2026-07-31T09:14:22Z");
+    expect(parsed.crons).toBe(3);
+  });
+
+  it("should leave the traffic record unknown rather than empty on an older bay-go", () => {
+    // A binary that predates the proxy's bookkeeping reports neither field.
+    // Both must stay undefined: a `crons: 0` nobody measured would claim an app
+    // has no scheduled work, which is how a working mailer gets deleted.
+    const parsed = bayAppSchema.parse({
+      name: "demo",
+      env: "production",
+      domain: "demo.example.com",
+      release: "2026-07-31-120000",
+      port: 4000,
+      runtime: "node",
+    });
+
+    expect(parsed.lastRequestAt).toBeUndefined();
+    expect(parsed.crons).toBeUndefined();
+  });
 });

--- a/apps/bay-admin/test/quietLabel.spec.ts
+++ b/apps/bay-admin/test/quietLabel.spec.ts
@@ -1,0 +1,119 @@
+import { Alepha } from "alepha";
+import { DateTimeProvider } from "alepha/datetime";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { BayApp } from "../src/api/services/BayControlService.ts";
+import { quietLabel } from "../src/web/components/quietLabel.ts";
+
+describe("quietLabel", () => {
+  let dt: DateTimeProvider;
+
+  /*
+    Every instant here is expressed as an offset from now, never as a literal
+    date. `DateTimeProvider` can freeze the clock and move it forward, but it
+    cannot be pinned to a chosen absolute instant — so a test written against
+    fixed dates passes today and silently starts asserting "5 months" where it
+    meant "4" as real time advances past it.
+  */
+  const answeredDaysAgo = (days: number) =>
+    dt.now().subtract(days, "day").toISOString();
+
+  /**
+   * The same offset, spelled as a Bay release directory name.
+   */
+  const deployedDaysAgo = (days: number) =>
+    dt.now().subtract(days, "day").format("YYYY-MM-DD-HHmmss");
+
+  const app = (over: Partial<BayApp> = {}): BayApp => ({
+    name: "demo",
+    env: "production",
+    domain: "demo.example.com",
+    release: deployedDaysAgo(1),
+    port: 4000,
+    runtime: "node",
+    ...over,
+  });
+
+  beforeEach(async () => {
+    const alepha = Alepha.create();
+    dt = alepha.inject(DateTimeProvider);
+    await alepha.start();
+    // Frozen so the offsets above and the label computed inside quietLabel are
+    // read from the same instant.
+    dt.pause();
+  });
+
+  it("should say nothing about an app somebody used this morning", () => {
+    expect(quietLabel(app({ lastRequestAt: answeredDaysAgo(0) }), dt)).toBe(
+      undefined,
+    );
+  });
+
+  it("should say nothing just under the threshold, so a quiet fortnight is not an accusation", () => {
+    expect(quietLabel(app({ lastRequestAt: answeredDaysAgo(29) }), dt)).toBe(
+      undefined,
+    );
+  });
+
+  it("should call out an app nothing has touched in months", () => {
+    expect(quietLabel(app({ lastRequestAt: answeredDaysAgo(120) }), dt)).toBe(
+      "Quiet 4 months",
+    );
+  });
+
+  /*
+    The fallback that keeps the two ends of the scale apart. Both of the next
+    two apps have never answered a request; only one is a deletion candidate,
+    and without dating the silence from the deploy they render identically.
+  */
+  it("should not badge an app deployed moments ago that nobody has opened yet", () => {
+    const fresh = app({
+      release: deployedDaysAgo(0),
+      lastRequestAt: undefined,
+    });
+
+    expect(quietLabel(fresh, dt)).toBe(undefined);
+  });
+
+  it("should badge an app deployed long ago and never once opened", () => {
+    const forgotten = app({
+      release: deployedDaysAgo(150),
+      lastRequestAt: undefined,
+    });
+
+    expect(quietLabel(forgotten, dt)).toBe("Quiet 5 months");
+  });
+
+  /*
+    An app whose whole job is a weekly mailer serves nobody and reads as the
+    deadest thing on the host. The cron count is what stops it being deleted on
+    that reading.
+  */
+  it("should report declared crons alongside the silence", () => {
+    expect(
+      quietLabel(app({ lastRequestAt: answeredDaysAgo(120), crons: 3 }), dt),
+    ).toBe("Quiet 4 months · 3 crons");
+  });
+
+  it("should not pluralise a single cron", () => {
+    expect(
+      quietLabel(app({ lastRequestAt: answeredDaysAgo(120), crons: 1 }), dt),
+    ).toBe("Quiet 4 months · 1 cron");
+  });
+
+  /*
+    An older bay-go does not report `crons` at all, and absent means unknown,
+    not none. Rendering "0 crons" would be a claim nobody made — and it is
+    exactly the false reassurance that gets a working app deleted.
+  */
+  it("should claim nothing about crons when the server did not report them", () => {
+    expect(quietLabel(app({ lastRequestAt: answeredDaysAgo(120) }), dt)).toBe(
+      "Quiet 4 months",
+    );
+  });
+
+  it("should say nothing at all when there is no date to reason from", () => {
+    expect(
+      quietLabel(app({ release: "unparseable", lastRequestAt: undefined }), dt),
+    ).toBe(undefined);
+  });
+});

--- a/apps/bay/.gitignore
+++ b/apps/bay/.gitignore
@@ -1,8 +1,11 @@
 # Anchored with a leading slash on purpose. A bare `bay` matches ANY path
 # component of that name, so it swallowed the whole `cmd/bay/` directory — the
 # CLI, the server and the control API — and `git add apps/bay` would have
-# committed a module with no `main` package. Nothing catches that: Go is not in
-# the CI pipeline.
+# committed a module with no `main` package.
+#
+# Nothing caught that at the time, because Go was not in CI. It is now — the
+# `bay` job in .github/workflows/ci.yml builds and tests on ubuntu-latest, and
+# `yarn v` runs the same steps locally through `yarn w bay test:linux`.
 /bay
 /bay-data/
 

--- a/apps/bay/Dockerfile
+++ b/apps/bay/Dockerfile
@@ -1,0 +1,54 @@
+# Runs Bay's checks on Linux, from a macOS working tree.
+#
+# Not a build image — nothing here ships. Bay's release binary is cross-compiled
+# by the release workflow. This exists for one reason: `go test` on macOS is
+# green while skipping every test of `Systemd.render()`, because those files are
+# `//go:build linux` and the toolchain excludes them outright.
+#
+# The source is NOT copied in. It arrives as a read-only bind mount at run time,
+# so what gets tested is the working tree — uncommitted changes included, which
+# is the whole point of running this before a push.
+
+# Pinned here rather than passed in, because Compose interpolates its whole file
+# before consulting profiles — a required build arg for this service would make
+# a plain `docker compose up` fail for postgres and redis too.
+#
+# The duplicate with go.mod is deliberate and is not left on trust, though the
+# two directions fail differently:
+#
+#   too OLD — caught here, at build time. The official golang images set
+#   GOTOOLCHAIN=local, so `go mod download` refuses outright with
+#   "go.mod requires go >= 1.26.1 (running go 1.25.12)". Nothing to add.
+#
+#   too NEW — silent. A newer toolchain runs an older go.mod happily, so
+#   writing `1.26` here (which resolves to the latest 1.26.x) would test Bay on
+#   a Go it does not ship on, and say nothing. That is the case ci.sh catches,
+#   by comparing the running toolchain against the `go` directive.
+ARG GO_VERSION=1.26.1
+FROM golang:${GO_VERSION}
+
+WORKDIR /src
+
+# Dependencies in their own layer, baked into the image.
+#
+# The alternative was bind-mounting the host's module cache, which worked but
+# had the container (running as root) writing into a directory owned by the
+# user. Invisible under Docker Desktop, where file ownership is virtualised —
+# and on a Linux workstation it leaves root-owned files in ~/go/pkg/mod that
+# their owner then cannot delete.
+#
+# Docker rebuilds this layer when go.mod or go.sum changes and reuses it
+# otherwise, so the version stays correct with nothing to remember.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Modules are already present and the source is mounted read-only, so nothing
+# may reach out to the network or rewrite go.mod mid-run. A missing dependency
+# must fail here, loudly, rather than be fetched and silently recorded.
+ENV GOFLAGS=-mod=readonly
+
+# GOCACHE defaults under HOME; naming it explicitly keeps every write inside the
+# container, which is what allows the source mount to be read-only.
+ENV GOCACHE=/tmp/go-build
+
+CMD ["./ci.sh"]

--- a/apps/bay/ci.sh
+++ b/apps/bay/ci.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+#
+# The checks Bay must pass, in the order the `bay` CI job runs them.
+#
+# A file of its own rather than a string passed to `sh -c`, so there is no
+# nested quoting to work around — the previous version could not write an
+# apostrophe in its own error message.
+#
+# Run inside the container by `test-linux.sh`, and mirrored by
+# .github/workflows/ci.yml. The two must stay in step: this one exists so a
+# break is found before the push, not by the push.
+
+set -eu
+
+# The toolchain must be the one go.mod asks for.
+#
+# Specifically the too-NEW direction, which is the one nothing else catches. An
+# image older than go.mod already fails at build time — the official golang
+# images set GOTOOLCHAIN=local, so `go mod download` refuses and names both
+# versions. But a NEWER toolchain runs an older go.mod perfectly happily: pin
+# `1.26` in the Dockerfile instead of `1.26.1` and you silently test Bay on
+# 1.26.5, which is not what it ships on. Verified: that exact pin trips this.
+want=$(awk '/^go /{print $2; exit}' go.mod)
+have=$(go env GOVERSION | sed 's/^go//')
+if [ "$want" != "$have" ]; then
+  echo "ci: toolchain mismatch — go.mod wants $want, the image has $have." >&2
+  echo "  Update ARG GO_VERSION in apps/bay/Dockerfile to $want." >&2
+  exit 1
+fi
+
+# `gofmt -l` prints the files it dislikes and exits 0 either way, so the test
+# has to be on its output rather than on its status.
+unformatted=$(gofmt -l .)
+if [ -n "$unformatted" ]; then
+  echo "Not gofmt'd:" >&2
+  echo "$unformatted" >&2
+  exit 1
+fi
+
+go vet ./...
+go build ./...
+go test ./...
+
+# Bay is developed on macOS and only ever runs on Linux, so a break specific to
+# one target architecture would otherwise surface on the VPS rather than here.
+for target in amd64 arm64; do
+  echo "-> linux/$target"
+  GOOS=linux GOARCH="$target" CGO_ENABLED=0 go build -o /dev/null ./cmd/bay
+done

--- a/apps/bay/cmd/bay/cpu.go
+++ b/apps/bay/cmd/bay/cpu.go
@@ -1,0 +1,32 @@
+package main
+
+import "fmt"
+
+/*
+cpuQuotaFor returns the per-app CPU ceiling for a host with `cores` CPUs.
+
+The policy is one sentence: **no single app may take more than half the
+machine.** Whatever else is happening, the other apps and — the part that
+matters — Bay's own proxy always have the other half. A prototype in a tight
+loop then costs its own latency instead of the whole host's, which is the
+difference between one broken app and a site-wide outage.
+
+Derived from the core count rather than hardcoded because the machine is
+expected to grow. A fixed "100%" is half of a two-core VPS and a quarter of a
+four-core one, so the protection would silently tighten every time the host is
+upgraded — exactly when the operator expects the opposite.
+
+The floor of 100% is not a rounding convenience. On a single-core host every
+possible ceiling is either the whole machine or a handicap, so there is no
+protection to buy; taking the handicap would double cold-start times on the
+machine least able to afford it. It also keeps a zero or negative core count
+— which `runtime.NumCPU` never returns, but a caller might — from rendering
+`CPUQuota=0%`, which grants no CPU at all and leaves an app that never boots.
+*/
+func cpuQuotaFor(cores int) string {
+	percent := cores * 50
+	if percent < 100 {
+		percent = 100
+	}
+	return fmt.Sprintf("%d%%", percent)
+}

--- a/apps/bay/cmd/bay/cpu_test.go
+++ b/apps/bay/cmd/bay/cpu_test.go
@@ -1,0 +1,36 @@
+package main
+
+import "testing"
+
+// The policy in one sentence: no single app may take more than half the
+// machine, so the other apps and Bay's own proxy always have the other half.
+func TestCPUQuotaForLeavesHalfTheMachine(t *testing.T) {
+	cases := []struct {
+		name  string
+		cores int
+		want  string
+	}{
+		// The VPS Bay actually runs on. One core for the busiest app, one for
+		// everything else.
+		{"two cores", 2, "100%"},
+		{"four cores", 4, "200%"},
+		{"eight cores", 8, "400%"},
+		// Half a core would make a cold start twice as slow on the machine
+		// least able to afford it, and there is no protection to buy anyway:
+		// with one core, every ceiling is either the whole machine or a
+		// handicap. The floor says so out loud.
+		{"one core cannot be divided", 1, "100%"},
+		// runtime.NumCPU never returns zero, but a zero reaching this must not
+		// render "0%" — that grants no CPU at all and the app never boots.
+		{"zero is not a starvation order", 0, "100%"},
+		{"negative is not a starvation order", -4, "100%"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cpuQuotaFor(tc.cores); got != tc.want {
+				t.Fatalf("cpuQuotaFor(%d) = %q, want %q", tc.cores, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/bay/cmd/bay/keep.go
+++ b/apps/bay/cmd/bay/keep.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"errors"
+	"strconv"
+)
+
+/*
+parseKeepReleases reads the --keep-releases value.
+
+Its own function because it is the one flag whose value DELETES things, and the
+difference between refusing a bad value and falling back to a default is the
+difference between an operator seeing their typo and an operator believing a
+retention policy they never set. Same refusal as --backup-interval, for the
+same reason, with more at stake.
+
+Floored at two, not one. Automatic rollback swaps `current` back to the release
+that was serving a moment ago, so keeping only the newest would delete the very
+target `watchAndRollback` reaches for — and the safety net would fail silently,
+at the one moment it is load bearing. Rollback needs somewhere to go.
+
+`strconv.Atoi` rather than anything more forgiving: it rejects "5.9" and
+"5releases" outright, where a lenient parse would silently keep a number the
+operator never typed.
+*/
+func parseKeepReleases(value string) (int, error) {
+	n, err := strconv.Atoi(value)
+	if err != nil || n < 2 {
+		return 0, errors.New("must be a whole number of at least 2")
+	}
+	return n, nil
+}

--- a/apps/bay/cmd/bay/keep_test.go
+++ b/apps/bay/cmd/bay/keep_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+// parseKeepReleases guards a flag that DELETES things, so every rejection below
+// is a case where accepting the input would have quietly removed releases an
+// operator still needed.
+func TestParseKeepReleases(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"an ordinary count", "5", 5, false},
+		{"the floor", "2", 2, false},
+		{"a large count", "40", 40, false},
+		// One release means `watchAndRollback` has nowhere to return to: the
+		// release it wants is the one this would have deleted. The safety net
+		// would fail silently, at the only moment it matters.
+		{"one leaves rollback with no target", "1", 0, true},
+		// The dangerous reading of a zero-valued or misparsed flag is "keep
+		// nothing". It must never be spelled this way.
+		{"zero", "0", 0, true},
+		{"negative", "-3", 0, true},
+		{"not a number", "five", 0, true},
+		{"empty", "", 0, true},
+		// `strconv.Atoi` rejects these, and it must stay that way: a silent
+		// truncation of "5.9" to 5 is a value the operator never typed.
+		{"a decimal", "5.9", 0, true},
+		{"trailing text", "5releases", 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseKeepReleases(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseKeepReleases(%q) = %d, want an error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseKeepReleases(%q) = %v, want %d", tc.in, err, tc.want)
+			}
+			if got != tc.want {
+				t.Fatalf("parseKeepReleases(%q) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/bay/cmd/bay/lastseen.go
+++ b/apps/bay/cmd/bay/lastseen.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"time"
+)
+
+// lastSeenFlushInterval is how often accumulated traffic reaches state.json.
+//
+// Generous on purpose. The question this feeds is "has anything touched this
+// app in the last N weeks?", so minutes of precision are already far more than
+// the answer can use, and every minute of coarseness is one fewer rewrite of
+// the whole state document.
+const lastSeenFlushInterval = 5 * time.Minute
+
+/*
+flushLastSeenLoop moves the proxy's in-memory traffic record into the store.
+
+Split from the request path so that serving a page never writes to disk: the
+store rewrites the entire document with temp-and-rename, and doing that per
+request would put a filesystem round trip in front of every asset.
+
+Ticks only. The final drain is NOT done here — cancelling a context merely makes
+a goroutine runnable, so a flush on the way out would race `main` returning and
+lose whatever it was trying to save. `cmdServe` calls `flushLastSeen` itself,
+synchronously, after the proxy has drained.
+*/
+func (s *server) flushLastSeenLoop(ctx context.Context) {
+	ticker := time.NewTicker(lastSeenFlushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.flushLastSeen()
+		}
+	}
+}
+
+// flushLastSeen persists one batch.
+//
+// A failure is logged and dropped rather than retried: the batch is already
+// gone from the proxy, and re-reading it is not worth a retry queue for a
+// timestamp whose only consumer asks about weeks. What must not happen is
+// silence — a staleness badge that quietly stops advancing reads exactly like
+// an app nobody uses.
+func (s *server) flushLastSeen() {
+	if s.router == nil {
+		return
+	}
+	for key, at := range s.router.DrainLastSeen() {
+		if err := s.store.RecordLastRequest(key, at); err != nil {
+			s.log.Error("recording traffic failed", "app", key, "err", err)
+		}
+	}
+}

--- a/apps/bay/cmd/bay/main.go
+++ b/apps/bay/cmd/bay/main.go
@@ -596,8 +596,8 @@ The returned list is handed back to the deploy caller as well as logged. A
 retention policy nobody can observe is indistinguishable from releases
 vanishing on their own.
 */
-func (s *server) pruneReleases(app state.App) []string {
-	removed, err := deploy.Prune(s.instanceDir(app), s.keepReleases)
+func (s *server) pruneReleases(app state.App, protect ...string) []string {
+	removed, err := deploy.Prune(s.instanceDir(app), s.keepReleases, protect...)
 	if err != nil {
 		// Logged alongside whatever was already deleted: a half-completed prune
 		// that reports nothing is how disk usage stops adding up.
@@ -830,9 +830,15 @@ func (s *server) handleDeploy(w http.ResponseWriter, r *http.Request) {
 	//
 	// Pruning before the health check would destroy rollback targets on behalf
 	// of a release that turns out not to start — taking away the escape route at
-	// exactly the moment it is needed. The floor of two on --keep-releases is
-	// what keeps `res.Previous` out of reach of this call.
-	pruned := s.pruneReleases(res.App)
+	// exactly the moment it is needed.
+	//
+	// `res.Previous` is named explicitly rather than left to the keep window,
+	// which does not cover it. It is whatever `state.Release` held before this
+	// deploy, and a manual `bay rollback` sets that to any release the operator
+	// chose — so after rollback-then-deploy the target of the watch started just
+	// above can sit well outside the newest five, with `current` already
+	// repointed here and no longer protecting it.
+	pruned := s.pruneReleases(res.App, res.Previous)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"app":           res.App,

--- a/apps/bay/cmd/bay/main.go
+++ b/apps/bay/cmd/bay/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -58,6 +59,18 @@ const (
 	// defaultBackupInterval is deliberately ON by default. Backups that must be
 	// switched on are backups that stay off.
 	defaultBackupInterval = 24 * time.Hour
+	// defaultKeepReleases bounds how many releases each app keeps on disk.
+	//
+	// ON by default, for the same reason backups are: nothing removed releases
+	// before this, and on a host with twenty apps that is the disk filling up.
+	// A full disk does not take down the app being deployed, it takes down every
+	// app on the machine plus the backups and Bay's own state writes.
+	//
+	// Five rather than one because the proxy serves static files from every
+	// retained release, so a client holding the previous page's HTML can still
+	// fetch its hashed chunks after a deploy — and because retained releases are
+	// the rollback targets. Both want depth, neither wants forty.
+	defaultKeepReleases = 5
 	// defaultControlGroup is the unix group whose members may reach the control
 	// socket. Membership is the whole authorization: joining it is equivalent to
 	// being handed the token.
@@ -154,6 +167,7 @@ func usage() {
               [--acme-ca-root FILE.pem]   # trust a private CA (Pebble, step-ca)
               [--acme-http-port N] [--acme-tls-port N]   # challenge ports, default 80/443
               [--backup-interval 24h]   # 0 disables; needs "bay config s3"
+            [--keep-releases 5]   # per app; min 2, the serving one is always kept
   bay deploy  <app.tar.gz> [--name NAME] [--env ENV] [--domain HOST]
               # --name defaults to the artifact's project, and drives BOTH the
               # instance key and the subdomain: one app, one identity
@@ -240,6 +254,9 @@ type server struct {
 	// router is told when an app is being restarted, so requests wait for the
 	// new process instead of failing. Nil in the CLI paths that never serve.
 	router *proxy.Proxy
+	// keepReleases is how many releases survive a prune. Zero in the CLI paths
+	// that never deploy, where `deploy.Prune` treats it as "delete nothing".
+	keepReleases int
 	// watches holds the cancel of each app's in-flight rollback watch, so a new
 	// deploy can supersede the previous one's. See beginWatch.
 	watchMu sync.Mutex
@@ -256,6 +273,8 @@ func cmdServe(args []string) error {
 	useTLS := false
 	backupInterval := defaultBackupInterval
 	badBackupInterval := ""
+	keepReleases := defaultKeepReleases
+	badKeepReleases := ""
 	controlSocket := ""
 	controlGroup := defaultControlGroup
 	if err := checkFlags(args,
@@ -266,7 +285,7 @@ func cmdServe(args []string) error {
 			"--acme-ca": true, "--acme-email": true, "--acme-ca-root": true,
 			"--acme-http-port": true, "--acme-tls-port": true,
 			"--control-socket": true, "--control-group": true,
-			"--backup-interval": true,
+			"--backup-interval": true, "--keep-releases": true,
 		}); err != nil {
 		return err
 	}
@@ -311,10 +330,20 @@ func cmdServe(args []string) error {
 				// a typo would leave someone believing backups are configured.
 				badBackupInterval = args[i+1]
 			}
+		case "--keep-releases":
+			n, parseErr := parseKeepReleases(args[i+1])
+			if parseErr == nil {
+				keepReleases = n
+			} else {
+				badKeepReleases = args[i+1]
+			}
 		}
 	}
 	if badBackupInterval != "" {
 		return fmt.Errorf("--backup-interval %q is not a duration (try 24h, 12h, 0 to disable)", badBackupInterval)
+	}
+	if badKeepReleases != "" {
+		return fmt.Errorf("--keep-releases %q must be a whole number of at least 2 (try 5): automatic rollback needs a previous release to return to, and the serving release is always kept on top", badKeepReleases)
 	}
 	root, err := filepath.Abs(root)
 	if err != nil {
@@ -355,7 +384,7 @@ func cmdServe(args []string) error {
 	}
 	srv := &server{root: root, runtimes: runtimesDir, store: store, runner: sup,
 		isolated: isolated, log: log, controlSocket: controlSocket,
-		probe: &health.Probe{}}
+		keepReleases: keepReleases, probe: &health.Probe{}}
 
 	router := proxy.New(root, store, log)
 	srv.router = router
@@ -466,6 +495,19 @@ func cmdServe(args []string) error {
 		}
 	}()
 
+	// Trim release history BEFORE starting anything, and this order is the whole
+	// reason there is a prune at startup at all.
+	//
+	// An installation that predates the retention policy has every release it
+	// has ever deployed still on disk. If the disk is already full, the next
+	// deploy fails during the unpack — before it could ever reach the prune that
+	// runs after a successful one — so the only code that can free space would
+	// never run. Doing it on the way up is what lets a full machine recover
+	// without someone SSHing in with `rm -rf`.
+	for _, app := range store.Apps() {
+		srv.pruneReleases(app)
+	}
+
 	// Bring previously deployed apps back up after a bay restart.
 	for _, app := range store.Apps() {
 		if err := srv.start(app); err != nil {
@@ -480,6 +522,9 @@ func cmdServe(args []string) error {
 	defer stopBackups()
 	go srv.backupLoop(backupCtx, backupInterval)
 
+	// Traffic bookkeeping, drained from the proxy on its own schedule.
+	go srv.flushLastSeenLoop(backupCtx)
+
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 	<-stop
@@ -492,6 +537,17 @@ func cmdServe(args []string) error {
 	defer cancel()
 	_ = proxySrv.Shutdown(ctx)
 	_ = socketSrv.Shutdown(ctx)
+
+	// Synchronously, and only once the proxy has drained: anything served during
+	// the shutdown window is still traffic, and this is the last moment it can
+	// be recorded.
+	//
+	// Not left to the flush loop's own ctx.Done branch. Cancelling a context
+	// only makes a goroutine runnable, so that flush would race `main` returning
+	// — and an operator restarting Bay a few times in a row would keep discarding
+	// the freshness they are about to go and read.
+	srv.flushLastSeen()
+
 	srv.runner.StopAll(stopGrace)
 	return nil
 }
@@ -523,6 +579,37 @@ func (s *server) holdDuring(key string) func() {
 // Starting and being ready are different things: routing traffic at a process
 // that is still running migrations is exactly the mistake this separation
 // prevents.
+// instanceDir is where an app instance's durable state lives — its .env, its
+// database, its storage and its releases.
+func (s *server) instanceDir(app state.App) string {
+	return filepath.Join(s.root, "apps", app.Name, app.Env)
+}
+
+/*
+pruneReleases trims an app's release history and reports what it removed.
+
+Never fatal, at either call site. A prune that fails is a disk that fills up
+later — something an operator needs to read in the log, not a reason to fail a
+deploy that has already succeeded, nor to stop Bay from booting the other apps.
+
+The returned list is handed back to the deploy caller as well as logged. A
+retention policy nobody can observe is indistinguishable from releases
+vanishing on their own.
+*/
+func (s *server) pruneReleases(app state.App) []string {
+	removed, err := deploy.Prune(s.instanceDir(app), s.keepReleases)
+	if err != nil {
+		// Logged alongside whatever was already deleted: a half-completed prune
+		// that reports nothing is how disk usage stops adding up.
+		s.log.Error("prune releases failed", "app", app.Key(), "removed", removed, "err", err)
+	}
+	if len(removed) > 0 {
+		s.log.Info("pruned old releases",
+			"app", app.Key(), "keep", s.keepReleases, "removed", removed)
+	}
+	return removed
+}
+
 func (s *server) start(app state.App) error {
 	instance := filepath.Join(s.root, "apps", app.Name, app.Env)
 	env, err := runner.LoadEnvFile(filepath.Join(instance, ".env"))
@@ -561,6 +648,7 @@ func (s *server) start(app state.App) error {
 			WritablePaths: writable,
 			MemoryMax:     "512M",
 			TasksMax:      256,
+			CPUQuota:      cpuQuotaFor(runtime.NumCPU()),
 			StopGrace:     stopGrace,
 			ControlGroup:  controlGroupFor(app),
 			// Widened only for a granted app; empty otherwise.
@@ -738,12 +826,21 @@ func (s *server) handleDeploy(w http.ResponseWriter, r *http.Request) {
 		go s.watchAndRollback(res.App, res.Previous)
 	}
 
+	// Trimmed only now, after the app has been proven to boot.
+	//
+	// Pruning before the health check would destroy rollback targets on behalf
+	// of a release that turns out not to start — taking away the escape route at
+	// exactly the moment it is needed. The floor of two on --keep-releases is
+	// what keeps `res.Previous` out of reach of this call.
+	pruned := s.pruneReleases(res.App)
+
 	writeJSON(w, http.StatusOK, map[string]any{
 		"app":           res.App,
 		"release":       res.Release,
 		"url":           "https://" + res.App.Domain + "/",
 		"sleepEligible": res.Manifest.SleepEligible(),
 		"restore":       restore,
+		"pruned":        pruned,
 	})
 }
 

--- a/apps/bay/internal/deploy/deploy.go
+++ b/apps/bay/internal/deploy/deploy.go
@@ -195,6 +195,10 @@ func Run(opts Options, store *state.Store) (*Result, error) {
 		// Only a Bay-provisioned database can be snapshotted; a BYO DATABASE_URL
 		// leaves dbPath empty.
 		Backups: dbPath != "",
+		// Carried so an app that serves nobody on purpose — a weekly mailer, a
+		// nightly import — can be told apart from one that has been abandoned.
+		// Both read as zero traffic; only one of them should be deleted.
+		Crons: len(m.Cron),
 	}
 	// Preserved across redeploys unless the caller asks again: revoking should be
 	// deliberate, not a side effect of forgetting a flag. `Upsert` carries the

--- a/apps/bay/internal/deploy/prune.go
+++ b/apps/bay/internal/deploy/prune.go
@@ -24,11 +24,21 @@ a deploy instead of getting a white screen. That needs a release or two of
 depth, not forty. Retained releases are also the rollback targets, which is the
 other reason the number is more than one.
 
+`protect` names releases that must survive whatever the window says, on top of
+the one `current` points at. It exists for `Result.Previous`, the target an
+in-flight `watchAndRollback` is holding: a manual `bay rollback` sets
+`state.Release` to any release the operator named, so after rollback-then-deploy
+that target sits outside the keep window AND outside the symlink, which has just
+been repointed at the release that landed. Removing it does not lose a
+directory, it loses the escape route — the rollback then fails on a path that is
+gone, at the one moment it is load bearing. Empty names are ignored, so a first
+deploy can pass its (empty) previous through without testing it.
+
 Returns what it removed, and callers log it. A retention policy nobody can
 observe is indistinguishable from releases disappearing on their own — the same
 reason `backup.Prune` reports its deletions.
 */
-func Prune(instance string, keep int) ([]string, error) {
+func Prune(instance string, keep int, protect ...string) ([]string, error) {
 	// A keep of zero reaching this point is a misparsed flag or a zero-valued
 	// struct field, never an operator asking to delete every release. Between
 	// the destructive reading of an obviously wrong input and the inert one,
@@ -56,9 +66,22 @@ func Prune(instance string, keep int) ([]string, error) {
 		return nil, err
 	}
 
+	// The serving release and the caller's additions in one set, so the loop
+	// below has a single rule rather than a growing list of exceptions.
+	//
+	// Built by ranging rather than appending `serving` onto `protect`: a caller
+	// spreading its own slice would have that slice written to underneath it.
+	keeping := map[string]bool{serving: true}
+	for _, name := range protect {
+		keeping[name] = true
+	}
+	// A missing `current` and a first deploy's empty previous both arrive as "",
+	// and neither names a release.
+	delete(keeping, "")
+
 	var removed []string
 	for _, name := range releases[keep:] {
-		if name == serving {
+		if keeping[name] {
 			continue
 		}
 		if err := os.RemoveAll(filepath.Join(instance, "releases", name)); err != nil {

--- a/apps/bay/internal/deploy/prune.go
+++ b/apps/bay/internal/deploy/prune.go
@@ -1,0 +1,96 @@
+package deploy
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+/*
+Prune deletes all but the `keep` most recent releases of an app instance.
+
+Releases accumulate on every deploy and nothing removed them: on a host with
+twenty apps that is the disk filling up, and a full disk does not take down the
+app that was being deployed — it takes down every app, plus the backups and
+Bay's own state writes. It is the one failure here whose blast radius is the
+whole machine.
+
+Keeping several rather than only `current` is not sentimentality. The proxy
+serves static files from EVERY retained release (see `proxy.findStatic`), so a
+client still holding the previous page's HTML can fetch its hashed chunks after
+a deploy instead of getting a white screen. That needs a release or two of
+depth, not forty. Retained releases are also the rollback targets, which is the
+other reason the number is more than one.
+
+Returns what it removed, and callers log it. A retention policy nobody can
+observe is indistinguishable from releases disappearing on their own — the same
+reason `backup.Prune` reports its deletions.
+*/
+func Prune(instance string, keep int) ([]string, error) {
+	// A keep of zero reaching this point is a misparsed flag or a zero-valued
+	// struct field, never an operator asking to delete every release. Between
+	// the destructive reading of an obviously wrong input and the inert one,
+	// this takes the inert one.
+	if keep <= 0 {
+		return nil, nil
+	}
+
+	releases, err := Releases(instance)
+	if err != nil {
+		// An app registered in the state but never successfully deployed has no
+		// releases directory. Prune runs across every app at startup, and a hard
+		// error on one empty instance would keep Bay from booting the others.
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(releases) <= keep {
+		return nil, nil
+	}
+
+	serving, err := servingRelease(instance)
+	if err != nil {
+		return nil, err
+	}
+
+	var removed []string
+	for _, name := range releases[keep:] {
+		if name == serving {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(instance, "releases", name)); err != nil {
+			// Report what was already deleted alongside the failure: the caller
+			// logs it, and a half-completed prune that says nothing is how disk
+			// usage becomes impossible to account for.
+			return removed, fmt.Errorf("remove release %s: %w", name, err)
+		}
+		removed = append(removed, name)
+	}
+	return removed, nil
+}
+
+/*
+servingRelease reports which release `current` points at.
+
+Resolved here rather than taken as an argument, and rather than assumed to be
+the newest: after `bay rollback` the serving release is an OLD one, so pruning
+by age alone would delete the running app's own directory out from under it.
+
+A missing `current` is a fact, not a failure — an app whose first deploy died
+between the unpack and the swap has releases and no symlink, and there is
+nothing to protect. Any OTHER error is the unknown case, and the caller must
+not delete anything while it cannot tell what is serving.
+*/
+func servingRelease(instance string) (string, error) {
+	target, err := os.Readlink(filepath.Join(instance, "current"))
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("resolve current release: %w", err)
+	}
+	return filepath.Base(target), nil
+}

--- a/apps/bay/internal/deploy/prune_test.go
+++ b/apps/bay/internal/deploy/prune_test.go
@@ -1,0 +1,153 @@
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// remaining lists the release directories still on disk, for asserting on what
+// survived rather than only on what Prune claimed to remove. The two can
+// disagree, and the disk is the one that matters.
+func remaining(t *testing.T, instance string) map[string]bool {
+	t.Helper()
+	entries, err := os.ReadDir(filepath.Join(instance, "releases"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]bool{}
+	for _, e := range entries {
+		out[e.Name()] = true
+	}
+	return out
+}
+
+func TestPruneKeepsTheMostRecentReleases(t *testing.T) {
+	instance := t.TempDir()
+	for _, name := range []string{
+		"2026-07-25-100000",
+		"2026-07-26-100000",
+		"2026-07-27-100000",
+		"2026-07-28-100000",
+		"2026-07-29-100000",
+	} {
+		release(t, instance, name)
+	}
+	if err := SwapRelease(instance, "2026-07-29-100000"); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := Prune(instance, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	left := remaining(t, instance)
+	if !left["2026-07-29-100000"] || !left["2026-07-28-100000"] {
+		t.Fatalf("the two most recent releases must survive, got %v", left)
+	}
+	if len(removed) != 3 {
+		t.Fatalf("expected the three oldest removed, got %v", removed)
+	}
+	for _, name := range removed {
+		if left[name] {
+			t.Fatalf("%s was reported removed but is still on disk", name)
+		}
+	}
+}
+
+// The rollback case, and the reason Prune resolves `current` itself rather than
+// trusting the sort order: after `bay rollback`, the serving release is an OLD
+// one. Pruning by age alone would delete the running app's own directory.
+func TestPruneNeverDeletesWhatCurrentPointsTo(t *testing.T) {
+	instance := t.TempDir()
+	for _, name := range []string{
+		"2026-07-25-100000",
+		"2026-07-26-100000",
+		"2026-07-27-100000",
+		"2026-07-28-100000",
+		"2026-07-29-100000",
+	} {
+		release(t, instance, name)
+	}
+	// Rolled back to the oldest release, which is outside any keep window.
+	if err := SwapRelease(instance, "2026-07-25-100000"); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := Prune(instance, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	left := remaining(t, instance)
+	if !left["2026-07-25-100000"] {
+		t.Fatal("the release `current` points to was deleted")
+	}
+	for _, name := range removed {
+		if name == "2026-07-25-100000" {
+			t.Fatal("Prune reported removing the serving release")
+		}
+	}
+	// The two newest are kept by the window, the serving one by the symlink.
+	if len(left) != 3 {
+		t.Fatalf("expected 2 kept by the window plus the serving one, got %v", left)
+	}
+}
+
+func TestPruneDoesNothingBelowTheKeepCount(t *testing.T) {
+	instance := t.TempDir()
+	release(t, instance, "2026-07-28-100000")
+	release(t, instance, "2026-07-29-100000")
+	if err := SwapRelease(instance, "2026-07-29-100000"); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := Prune(instance, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(removed) != 0 {
+		t.Fatalf("nothing should be removed below the keep count, got %v", removed)
+	}
+	if len(remaining(t, instance)) != 2 {
+		t.Fatal("both releases must survive")
+	}
+}
+
+// A keep of zero reaching this function means a misparsed flag or a zero-valued
+// struct field, never an operator asking for every release to be deleted. The
+// destructive reading of an obviously wrong input is the wrong one.
+func TestPruneWithANonPositiveKeepDeletesNothing(t *testing.T) {
+	instance := t.TempDir()
+	release(t, instance, "2026-07-28-100000")
+	release(t, instance, "2026-07-29-100000")
+
+	removed, err := Prune(instance, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(removed) != 0 {
+		t.Fatalf("a keep of zero must delete nothing, got %v", removed)
+	}
+	if len(remaining(t, instance)) != 2 {
+		t.Fatal("both releases must survive a keep of zero")
+	}
+}
+
+// Prune runs at startup across every app in the state, including one that has
+// been registered but never successfully deployed. A hard error there would
+// take Bay down on boot for an app that is merely empty.
+func TestPruneToleratesAnInstanceWithNoReleasesDirectory(t *testing.T) {
+	instance := t.TempDir()
+
+	removed, err := Prune(instance, 5)
+	if err != nil {
+		t.Fatalf("an instance with no releases must not be an error: %v", err)
+	}
+	if len(removed) != 0 {
+		t.Fatalf("nothing to remove, got %v", removed)
+	}
+}

--- a/apps/bay/internal/deploy/prune_test.go
+++ b/apps/bay/internal/deploy/prune_test.go
@@ -95,6 +95,84 @@ func TestPruneNeverDeletesWhatCurrentPointsTo(t *testing.T) {
 	}
 }
 
+/*
+The OTHER release a prune must not touch, and the one neither the keep window
+nor the `current` symlink covers.
+
+After a deploy, `Result.Previous` is what `state.Release` held a moment ago —
+and a manual `bay rollback` sets that to any release the operator named, not to
+the second newest. So rollback-then-deploy leaves the automatic rollback target
+sitting far outside the keep window, with `current` already repointed at the
+release that has just landed.
+
+Deleting it is not a lost directory, it is a lost escape route: if the new
+release then fails its health window, `watchAndRollback` calls `SwapRelease` on
+a path that no longer exists and the app stays on the bad release. The safety
+net disappears at the one moment it is load bearing.
+*/
+func TestPruneNeverDeletesTheRollbackTarget(t *testing.T) {
+	instance := t.TempDir()
+	for _, name := range []string{
+		"2026-07-20-100000", // the operator rolled back to this one
+		"2026-07-21-100000",
+		"2026-07-22-100000",
+		"2026-07-23-100000",
+		"2026-07-24-100000",
+		"2026-07-25-100000",
+		"2026-07-26-100000", // and then deployed this one
+	} {
+		release(t, instance, name)
+	}
+	// The deploy has already swapped `current`, so the release being rolled back
+	// FROM is the only thing the symlink protects now.
+	if err := SwapRelease(instance, "2026-07-26-100000"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Five is `defaultKeepReleases`: the bug needs the default, not a contrived
+	// window, because it is the shipped configuration that loses the target.
+	previous := "2026-07-20-100000"
+	removed, err := Prune(instance, 5, previous)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !remaining(t, instance)[previous] {
+		t.Fatalf("the rollback target was deleted; watchAndRollback has nowhere to go (removed %v)", removed)
+	}
+	for _, name := range removed {
+		if name == previous {
+			t.Fatalf("Prune reported removing the rollback target %s", previous)
+		}
+	}
+}
+
+// An empty name protects nothing and must not be mistaken for a release. A
+// first deploy has no previous release, and callers pass `res.Previous`
+// straight through rather than testing it themselves.
+func TestPruneIgnoresAnEmptyProtectedName(t *testing.T) {
+	instance := t.TempDir()
+	for _, name := range []string{
+		"2026-07-25-100000",
+		"2026-07-26-100000",
+		"2026-07-27-100000",
+	} {
+		release(t, instance, name)
+	}
+	if err := SwapRelease(instance, "2026-07-27-100000"); err != nil {
+		t.Fatal(err)
+	}
+
+	removed, err := Prune(instance, 2, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(removed) != 1 || removed[0] != "2026-07-25-100000" {
+		t.Fatalf("an empty name must protect nothing, got %v", removed)
+	}
+}
+
 func TestPruneDoesNothingBelowTheKeepCount(t *testing.T) {
 	instance := t.TempDir()
 	release(t, instance, "2026-07-28-100000")

--- a/apps/bay/internal/health/health.go
+++ b/apps/bay/internal/health/health.go
@@ -119,7 +119,26 @@ func (p *Probe) WaitReady(port int, timeout time.Duration) error {
 		status, hasHealth, err := p.Check(ctx, port)
 		switch {
 		case err != nil:
-			lastErr = err
+			/*
+				Kept only when it adds something.
+
+				`lastErr` is what the caller is told the wait failed for, and the
+				last probe of any wait is the one this function's own deadline
+				cuts off mid-request. Overwriting unconditionally therefore meant
+				the answer was ALWAYS the deadline: an app that had reported
+				`ready=false` three times came back as `context deadline
+				exceeded`, sending an operator to look at the network for an app
+				that was answering fine and merely was not ready yet.
+
+				`ctx.Err()` is the test rather than unwrapping the error, because
+				the same expiry surfaces differently depending on where it lands
+				— in the dial, in the round trip, in reading the body. If our own
+				context is already done, whatever came back is an artefact of
+				giving up, and it must not displace a real finding.
+			*/
+			if ctx.Err() == nil || lastErr == nil {
+				lastErr = err
+			}
 		case hasHealth && status.Ready:
 			return nil
 		case hasHealth:

--- a/apps/bay/internal/health/health_test.go
+++ b/apps/bay/internal/health/health_test.go
@@ -42,6 +42,43 @@ func TestWaitReadyAcceptsAReadyApp(t *testing.T) {
 	}
 }
 
+func TestWaitReadyBlamesTheAppRatherThanItsOwnDeadline(t *testing.T) {
+	/*
+		`lastErr` used to be overwritten on every pass, so the message came from
+		the FINAL probe — and the final probe is, by construction, the one the
+		deadline cuts off. An app that had answered `ready=false` three times
+		was therefore reported as `context deadline exceeded`, which sends an
+		operator to check the network for an app that was answering perfectly
+		well and simply was not ready. The folio's rule, exactly: never label a
+		response as a transport failure.
+
+		It is also what made `TestWaitReadyRefusesAnAppThatIsListeningButNotReady`
+		flaky. That test only passed when the last probe happened to land clear
+		of the deadline — true on an idle Mac, false about one run in six on a
+		loaded Linux box, where it failed on a message it never meant to assert.
+
+		Deterministic here rather than hopeful: the first probe answers, every
+		later one blocks until the context is cancelled. No timing to lose.
+	*/
+	var probes atomic.Int32
+	port := serveOn(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if probes.Add(1) == 1 {
+			fmt.Fprint(w, `{"ready":false}`)
+			return
+		}
+		<-r.Context().Done()
+	}))
+
+	err := (&Probe{}).WaitReady(port, 600*time.Millisecond)
+
+	if err == nil {
+		t.Fatal("an app that never becomes ready must not pass")
+	}
+	if !strings.Contains(err.Error(), "ready=false") {
+		t.Fatalf("the diagnosis must survive the deadline that ended the wait, got %v", err)
+	}
+}
+
 func TestWaitReadyRefusesAnAppThatIsListeningButNotReady(t *testing.T) {
 	// The bug this package exists for. An Alepha app binds its port before it
 	// has run migrations; the old TCP-only probe called that ready and Bay sent

--- a/apps/bay/internal/proxy/lastseen.go
+++ b/apps/bay/internal/proxy/lastseen.go
@@ -1,0 +1,77 @@
+package proxy
+
+import (
+	"sync"
+	"time"
+)
+
+/*
+lastSeen accumulates, in memory, when each app last answered a request.
+
+In memory and not straight to the store because this sits on the hot path:
+every request for every app goes through it, and `state.Store` writes the whole
+document with temp-and-rename. A ticker drains this instead, so the number of
+disk writes tracks the number of apps rather than the number of requests.
+
+Losing the tail on a crash is the accepted cost. The question this feeds is
+"has anything touched this app in the last N weeks?", and no answer to that
+changes because the final few minutes went missing.
+*/
+type lastSeen struct {
+	mu sync.Mutex
+	at map[string]time.Time
+}
+
+// touch records that an app answered a request at `now`.
+//
+// Keeps the newest of a batch: many requests land between two ticks, and the
+// first one would make a busy app look progressively staler with every flush.
+func (l *lastSeen) touch(key string, now time.Time) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.at == nil {
+		l.at = map[string]time.Time{}
+	}
+	if prev, ok := l.at[key]; ok && prev.After(now) {
+		return
+	}
+	l.at[key] = now
+}
+
+// drain returns what has accumulated and clears it.
+//
+// Clearing is what keeps the write rate proportional to traffic: without it,
+// every tick would rewrite state.json for every app that has ever been used,
+// forever, including the ones that have seen nothing for months.
+func (l *lastSeen) drain() map[string]time.Time {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := l.at
+	l.at = nil
+	if out == nil {
+		return map[string]time.Time{}
+	}
+	return out
+}
+
+/*
+countsAsTraffic reports whether a response means somebody is using the app.
+
+Not every request is evidence of use, and on Bay that distinction is
+load-bearing rather than fussy. Let's Encrypt publishes every certificate it
+issues to the Certificate Transparency logs, so each app's domain lands in a
+public, machine-readable list within minutes of getting HTTPS — and gets
+scanned. A prototype nobody has ever shared still receives traffic forever.
+
+Count raw requests and every abandoned app reads as freshly used, which is the
+one conclusion the staleness badge exists to prevent. So: the app must have
+answered. A bot walking a wordlist collects 404s and moves nothing; a person
+loading the page gets a 200 and does.
+
+5xx is excluded for a second reason. An app that is crash-looping returns 502
+from the proxy on every request, and counting those would rank the most broken
+app on the host as the most alive.
+*/
+func countsAsTraffic(status int) bool {
+	return status < 400
+}

--- a/apps/bay/internal/proxy/lastseen_test.go
+++ b/apps/bay/internal/proxy/lastseen_test.go
@@ -1,0 +1,148 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/alepha/bay/internal/state"
+)
+
+func TestLastSeenDrainReportsThenForgets(t *testing.T) {
+	// The proxy accumulates in memory and a ticker drains it, so the request
+	// path never touches the disk. Draining twice must not re-report: the
+	// second flush would rewrite state.json for apps that saw no traffic, and
+	// the write rate would track the ticker instead of the traffic.
+	var seen lastSeen
+	at := time.Unix(1700000000, 0)
+
+	seen.touch("lore/production", at)
+	seen.touch("demo/staging", at)
+
+	first := seen.drain()
+	if len(first) != 2 {
+		t.Fatalf("expected both apps in the first drain, got %v", first)
+	}
+	if !first["lore/production"].Equal(at) {
+		t.Fatalf("wrong timestamp carried through: %v", first["lore/production"])
+	}
+
+	if second := seen.drain(); len(second) != 0 {
+		t.Fatalf("a second drain with no traffic must be empty, got %v", second)
+	}
+}
+
+func TestLastSeenKeepsTheNewestOfABatch(t *testing.T) {
+	// Many requests land between two ticks. Only the most recent matters, and
+	// keeping the first would make a busy app look progressively staler.
+	var seen lastSeen
+	at := time.Unix(1700000000, 0)
+
+	seen.touch("lore/production", at)
+	seen.touch("lore/production", at.Add(30*time.Second))
+	seen.touch("lore/production", at.Add(10*time.Second))
+
+	got := seen.drain()
+	if !got["lore/production"].Equal(at.Add(30 * time.Second)) {
+		t.Fatalf("the newest stamp of the batch must win, got %v", got["lore/production"])
+	}
+}
+
+/*
+countsAsTraffic is the whole point of this file, so it gets the most tests.
+
+Every domain Bay serves is publicly enumerable: Let's Encrypt publishes each
+certificate it issues to the Certificate Transparency logs, so a prototype
+nobody has ever shared is in a public list within minutes of getting HTTPS, and
+it WILL be scanned. Counting raw requests would therefore show every abandoned
+app as freshly used, which is precisely the reading the badge exists to prevent.
+
+The rule: a request counts when the app actually answered it. A scanner probing
+/wp-login.php gets a 404 and does not move the needle; someone loading the page
+gets a 200 and does.
+*/
+// backendReturning starts an app that answers everything with one status, and
+// returns the port to point a state.App at.
+func backendReturning(t *testing.T, status int) int {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+/*
+The rule above is only worth anything if it is actually consulted, and the way
+it gets consulted is easy to lose: it hangs off `ModifyResponse`, a field on a
+reverse proxy built fresh for every request. Delete that assignment and every
+unit test in this file still passes while nothing is ever recorded again.
+
+So this one goes through the real forward path, against a real backend.
+*/
+func TestForwardRecordsOnlyRequestsTheAppAnswered(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		want   bool
+	}{
+		{"a served page is recorded", http.StatusOK, true},
+		{"a scanner collecting 404s is not", http.StatusNotFound, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestProxy(t)
+			app := state.App{Name: "demo", Env: "production", Port: backendReturning(t, tc.status)}
+
+			p.forward(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil), app)
+
+			_, recorded := p.DrainLastSeen()[app.Key()]
+			if recorded != tc.want {
+				t.Fatalf("a %d response recorded=%v, want %v", tc.status, recorded, tc.want)
+			}
+		})
+	}
+}
+
+func TestCountsAsTraffic(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		want   bool
+	}{
+		{"a served page", 200, true},
+		{"a conditional request from a returning visitor", 304, true},
+		{"a redirect the app chose to issue", 302, true},
+		// The upgrade handshake for a websocket. Someone is connecting.
+		{"a protocol switch", 101, true},
+		// Scanner territory. The app was reached, and it said there is nothing
+		// here — which is exactly what it says to a bot walking a wordlist.
+		{"a probe for a path that does not exist", 404, false},
+		{"a probe for something forbidden", 403, false},
+		{"an unauthenticated poke at an API", 401, false},
+		// A 500 means the app is broken, not that it is being used. Counting it
+		// would make a crash-looping app look healthiest of all.
+		{"an app erroring", 500, false},
+		{"the proxy's own bad gateway", 502, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countsAsTraffic(tc.status); got != tc.want {
+				t.Fatalf("countsAsTraffic(%d) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}

--- a/apps/bay/internal/proxy/proxy.go
+++ b/apps/bay/internal/proxy/proxy.go
@@ -32,6 +32,15 @@ type Proxy struct {
 	// connections at the start of a deploy affects nothing else.
 	transportOnce sync.Once
 	tr            *http.Transport
+	// seen accumulates when each app last answered, drained to the store on a
+	// ticker so the request path never writes to disk. See lastseen.go.
+	seen lastSeen
+}
+
+// DrainLastSeen returns the traffic recorded since the previous call, and
+// clears it. Called by the flush loop in cmd/bay, never on the request path.
+func (p *Proxy) DrainLastSeen() map[string]time.Time {
+	return p.seen.drain()
 }
 
 func New(root string, store *state.Store, log *slog.Logger) *Proxy {
@@ -70,6 +79,12 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// scale-to-zero viable, since a page pulls 10-30 asset requests that must
 	// never wake a sleeping process.
 	if path, ok := p.findStatic(app, r.URL.Path); ok {
+		// Counted without inspecting the response: findStatic has already
+		// stat'd the file, so what follows is a 200, a 304 or a range — all of
+		// them somebody reading this app. This is also the only place the
+		// traffic could be seen at all, since a page served entirely from disk
+		// never reaches the app process to be counted there.
+		p.seen.touch(app.Key(), time.Now())
 		p.serveStatic(w, r, path)
 		return
 	}
@@ -204,6 +219,30 @@ func (p *Proxy) forward(w http.ResponseWriter, r *http.Request, app state.App) {
 		base:     p.transport(),
 		holding:  func() bool { return p.holding(app.Key()) },
 		interval: 200 * time.Millisecond,
+	}
+
+	/*
+		Traffic is recorded here rather than by wrapping the ResponseWriter, and
+		that choice is load bearing.
+
+		A wrapper only forwards the methods it declares. `httputil.ReverseProxy`
+		asks the writer for `http.Flusher` to stream a response as it arrives —
+		Alepha's SSR flushes the document head early, so losing it would buffer
+		the very thing that makes first paint fast — and for `http.Hijacker` to
+		complete a websocket upgrade, which it refuses outright against a writer
+		that lacks it. Both failures are silent at compile time and invisible in
+		tests that only assert status codes.
+
+		`ModifyResponse` sees the status without touching the writer at all, and
+		it runs for a 101 too, so a websocket handshake counts as the use it is.
+		It must never return an error: that would route a perfectly good response
+		into ErrorHandler and turn it into a 502.
+	*/
+	rp.ModifyResponse = func(res *http.Response) error {
+		if countsAsTraffic(res.StatusCode) {
+			p.seen.touch(app.Key(), time.Now())
+		}
+		return nil
 	}
 
 	rp.ErrorHandler = func(w http.ResponseWriter, _ *http.Request, err error) {

--- a/apps/bay/internal/runner/sandbox_other.go
+++ b/apps/bay/internal/runner/sandbox_other.go
@@ -11,6 +11,10 @@ type Sandbox struct {
 	WritablePaths []string
 	MemoryMax     string
 	TasksMax      int
+	// CPUQuota is a cgroup CPU ceiling in systemd's spelling, e.g. "100%" for
+	// one core. Like MemoryMax it does nothing off Linux, where apps are plain
+	// child processes with no cgroup to charge.
+	CPUQuota string
 	// StopGrace is enforced by systemd's TimeoutStopSec in production. Off
 	// Linux the Child runner applies it itself, between SIGTERM and SIGKILL.
 	StopGrace time.Duration

--- a/apps/bay/internal/runner/systemd.go
+++ b/apps/bay/internal/runner/systemd.go
@@ -52,6 +52,19 @@ type Sandbox struct {
 	MemoryMax string
 	// TasksMax caps thread/process count. Zero means the systemd default.
 	TasksMax int
+	// CPUQuota is a cgroup CPU ceiling, in systemd's spelling: a percentage of
+	// ONE core, so "200%" is two full cores. Empty means unlimited.
+	//
+	// MemoryMax already stops one app from eating the host's RAM; without this
+	// nothing stopped it eating the host's CPU. On a small VPS a single app in a
+	// tight loop degrades every other app AND Bay's own proxy — which is what
+	// turns one broken prototype into a site-wide outage.
+	//
+	// A ceiling and not a share, deliberately. `CPUWeight` defaults to 100 on
+	// every unit, so setting it identically everywhere changes nothing; weights
+	// only do work when they differ. A quota is the one knob that still protects
+	// the host when every app is configured the same way.
+	CPUQuota string
 	// StopGrace is how long the app gets to shut down cleanly after SIGTERM,
 	// before systemd kills it.
 	//
@@ -270,6 +283,13 @@ func (s *Systemd) render(spec Spec, sandbox Sandbox, user string) string {
 	}
 	if sandbox.TasksMax > 0 {
 		w("TasksMax=%d", sandbox.TasksMax)
+	}
+	// Guarded on empty, and that guard is the load-bearing part: rendering an
+	// unset quota would emit `CPUQuota=0%`, which grants the app no CPU time at
+	// all. It would never finish booting, and the only symptom Bay could report
+	// is "never became ready" — a message nothing connects back to a quota.
+	if sandbox.CPUQuota != "" {
+		w("CPUQuota=%s", sandbox.CPUQuota)
 	}
 	w("")
 	w("StandardOutput=journal")

--- a/apps/bay/internal/runner/systemd_test.go
+++ b/apps/bay/internal/runner/systemd_test.go
@@ -8,8 +8,19 @@ import (
 	"time"
 )
 
-func renderUnitWith(t *testing.T, stopGrace time.Duration) string {
+// renderSandbox renders the demo unit with `adjust` applied to the sandbox, so
+// a test can vary one directive without restating the whole spec.
+func renderSandbox(t *testing.T, adjust func(*Sandbox)) string {
 	t.Helper()
+	sandbox := Sandbox{
+		Instance:      "/opt/bay/data/apps/demo/production",
+		WritablePaths: []string{"/opt/bay/data/apps/demo/production/scratch"},
+		MemoryMax:     "512M",
+		StopGrace:     30 * time.Second,
+	}
+	if adjust != nil {
+		adjust(&sandbox)
+	}
 	s := &Systemd{UnitDir: t.TempDir()}
 	return s.render(
 		Spec{
@@ -19,14 +30,14 @@ func renderUnitWith(t *testing.T, stopGrace time.Duration) string {
 			Entry:   "index.js",
 			LogFile: "/opt/bay/data/apps/demo/production/logs/app.log",
 		},
-		Sandbox{
-			Instance:      "/opt/bay/data/apps/demo/production",
-			WritablePaths: []string{"/opt/bay/data/apps/demo/production/scratch"},
-			MemoryMax:     "512M",
-			StopGrace:     stopGrace,
-		},
+		sandbox,
 		"bay-demo-production",
 	)
+}
+
+func renderUnitWith(t *testing.T, stopGrace time.Duration) string {
+	t.Helper()
+	return renderSandbox(t, func(s *Sandbox) { s.StopGrace = stopGrace })
 }
 
 func renderUnit(t *testing.T) string {
@@ -101,6 +112,41 @@ func TestUnitSandboxesTheApp(t *testing.T) {
 		if !strings.Contains(unit, directive) {
 			t.Errorf("missing sandbox directive %q", directive)
 		}
+	}
+}
+
+func TestUnitCapsCPUSoOneAppCannotTakeTheMachine(t *testing.T) {
+	/*
+		MemoryMax already stops one app from eating the host's RAM. Nothing
+		stopped it from eating the host's CPU — and on a two-core VPS a single
+		prototype in a tight loop degrades every other app AND Bay's own proxy,
+		which is the part that turns one broken app into a site-wide outage.
+
+		A ceiling rather than a share: `CPUWeight` is the default 100 for every
+		unit, so setting it uniformly changes nothing. Only a quota does work
+		when every app is configured identically.
+	*/
+	unit := renderSandbox(t, func(s *Sandbox) { s.CPUQuota = "100%" })
+
+	if !strings.Contains(unit, "CPUQuota=100%") {
+		t.Fatalf("the CPU ceiling the caller asked for must reach the unit:\n%s", unit)
+	}
+}
+
+func TestUnitOmitsCPUQuotaWhenUnset(t *testing.T) {
+	/*
+		The failure this forbids is not a missing limit, it is a rendered one:
+		`CPUQuota=0%` grants the app NO cpu time at all, so it would never
+		finish booting and Bay would report "never became ready" for a reason
+		nothing in the logs connects to a quota.
+
+		An unset field must therefore produce no line, leaving systemd's own
+		default — unlimited. Same shape as MemoryMax and TasksMax above.
+	*/
+	unit := renderSandbox(t, nil)
+
+	if strings.Contains(unit, "CPUQuota=") {
+		t.Fatalf("an unset quota must emit no directive at all:\n%s", unit)
 	}
 }
 

--- a/apps/bay/internal/state/state.go
+++ b/apps/bay/internal/state/state.go
@@ -54,6 +54,28 @@ type App struct {
 	// LastBackupError is when and why the most recent attempt failed. Cleared on
 	// the next success.
 	LastBackupError string `json:"lastBackupError,omitempty"`
+
+	// Crons is how many cron expressions the artifact declared. Derived from the
+	// manifest at deploy time, so it is replaced on every deploy rather than
+	// carried forward — it describes the release, not the instance.
+	//
+	// Stored only so that "no traffic in 92 days" can be read correctly. An app
+	// whose whole job is a weekly email serves nobody and would look abandoned;
+	// saying it has crons is what stops someone deleting it. Bay does not act on
+	// this, and deliberately does not store the expressions: it would then be
+	// tempted to schedule them, which Alepha already does better in-process.
+	Crons int `json:"crons,omitempty"`
+
+	// LastRequestAt is when this app last ANSWERED a request, RFC3339 UTC.
+	// Empty means it never has.
+	//
+	// The question it exists for is "which of these prototypes is dead?" — the
+	// one an operator actually asks when twenty of them share a host. Recorded
+	// by the proxy rather than reported by the app, because the proxy serves
+	// static files and prerendered HTML itself (see `proxy.findStatic`): an app
+	// that answers no requests at all can still be the one somebody reads every
+	// morning, and asking the app would call it idle.
+	LastRequestAt string `json:"lastRequestAt,omitempty"`
 }
 
 // Key is the stable identifier for an app instance.
@@ -167,6 +189,11 @@ func (s *Store) Upsert(app App) error {
 			app.LastBackupAt = a.LastBackupAt
 			app.LastBackupKey = a.LastBackupKey
 			app.LastBackupError = a.LastBackupError
+			// Traffic history belongs to the instance, not the release. Resetting
+			// it here would make every app read "no traffic ever" right after a
+			// deploy — so the staleness badge would be blank for exactly the apps
+			// someone is actively working on.
+			app.LastRequestAt = a.LastRequestAt
 			s.state.Apps[i] = app
 			return s.flush()
 		}
@@ -176,6 +203,32 @@ func (s *Store) Upsert(app App) error {
 }
 
 // RecordBackupSuccess stamps a completed backup.
+/*
+RecordLastRequest stamps when an app last answered a request.
+
+Monotonic on purpose. The proxy accumulates timestamps in memory and a ticker
+drains them, so a batch can arrive late — after a restart, or behind a slow
+flush — carrying a stamp older than one already recorded. Letting it win would
+make an app somebody just loaded read as abandoned, and a badge that says "no
+traffic for 40 days" about a page opened a minute ago is worse than no badge at
+all: it is the one reading that gets an app deleted.
+
+An unparseable stored value is overwritten rather than defended. It means the
+state was hand-edited or written by another version, and the current answer is
+worth more than an unreadable one.
+*/
+func (s *Store) RecordLastRequest(key string, at time.Time) error {
+	stamp := at.UTC().Format(time.RFC3339)
+	return s.mutate(key, func(a *App) {
+		if a.LastRequestAt != "" {
+			if prev, err := time.Parse(time.RFC3339, a.LastRequestAt); err == nil && prev.After(at) {
+				return
+			}
+		}
+		a.LastRequestAt = stamp
+	})
+}
+
 func (s *Store) RecordBackupSuccess(key, s3Key string, at time.Time) error {
 	return s.mutate(key, func(a *App) {
 		a.LastBackupAt = at.UTC().Format(time.RFC3339)

--- a/apps/bay/internal/state/state_test.go
+++ b/apps/bay/internal/state/state_test.go
@@ -113,9 +113,18 @@ func TestUpsertPreservesRuntimeOwnedFields(t *testing.T) {
 	if err := s.mutate("lore/production", func(a *App) { a.ControlAPI = true }); err != nil {
 		t.Fatal(err)
 	}
+	// Traffic history is the third. Resetting it on redeploy would mean the
+	// staleness badge reads "no traffic ever" for the apps someone is actively
+	// working on — the exact opposite of what it is for.
+	if err := s.RecordLastRequest("lore/production", time.Unix(1700000000, 0)); err != nil {
+		t.Fatal(err)
+	}
 
 	// A redeploy: same key, fresh record, new release.
-	if err := s.Upsert(App{Name: "lore", Env: "production", Port: 5000, Release: "2026-07-30-120000"}); err != nil {
+	if err := s.Upsert(App{
+		Name: "lore", Env: "production", Port: 5000,
+		Release: "2026-07-30-120000", Crons: 3,
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -126,6 +135,14 @@ func TestUpsertPreservesRuntimeOwnedFields(t *testing.T) {
 	if got.Release != "2026-07-30-120000" {
 		t.Fatalf("deploy-owned field should be taken from the argument, got %q", got.Release)
 	}
+	// The other half of the same rule, and the one that would rot quietly:
+	// `Crons` is derived from the artifact's manifest, so it must follow the
+	// release. Carrying it forward would leave an app that dropped its last
+	// cron looking, forever, like it still had one — and therefore never
+	// deletable on the strength of the badge.
+	if got.Crons != 3 {
+		t.Fatalf("Crons is derived from the manifest and must follow the release, got %d", got.Crons)
+	}
 	if got.LastBackupAt == "" {
 		t.Fatal("LastBackupAt must survive a redeploy")
 	}
@@ -134,6 +151,38 @@ func TestUpsertPreservesRuntimeOwnedFields(t *testing.T) {
 	}
 	if !got.ControlAPI {
 		t.Fatal("ControlAPI must survive a redeploy")
+	}
+	if got.LastRequestAt == "" {
+		t.Fatal("LastRequestAt must survive a redeploy")
+	}
+}
+
+func TestRecordLastRequestOnlyEverMovesForward(t *testing.T) {
+	// The proxy drains a batch of timestamps on a ticker, and a batch can be
+	// applied out of order after a restart or a slow flush. An older stamp
+	// overwriting a newer one would make an app that IS being used read as
+	// abandoned — a badge that says "no traffic for 40 days" about something
+	// someone loaded a minute ago is worse than no badge.
+	s, err := Open(filepath.Join(t.TempDir(), "state.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Upsert(App{Name: "lore", Env: "production", Port: 5000}); err != nil {
+		t.Fatal(err)
+	}
+
+	recent := time.Unix(1700000000, 0)
+	older := recent.Add(-2 * time.Hour)
+	if err := s.RecordLastRequest("lore/production", recent); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RecordLastRequest("lore/production", older); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := s.Get("lore/production")
+	if got.LastRequestAt != recent.UTC().Format(time.RFC3339) {
+		t.Fatalf("a late stamp must not rewind the record, got %q", got.LastRequestAt)
 	}
 }
 

--- a/apps/bay/package.json
+++ b/apps/bay/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bay",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "go test ./...",
+    "test:linux": "./test-linux.sh"
+  }
+}

--- a/apps/bay/test-linux.sh
+++ b/apps/bay/test-linux.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+#
+# Runs Bay's checks on Linux, from a macOS checkout.
+#
+# Why this exists: `go test ./...` on macOS is GREEN while running a fraction of
+# the suite. `internal/runner/systemd_test.go` opens with `//go:build linux`, so
+# the Go toolchain excludes the file outright — 5 of the 12 tests in that package
+# run natively, the other 7 do not exist, and nothing says so. `ok
+# internal/runner` is printed either way. Everything that unit tests
+# `Systemd.render()` — the sandbox directives, the memory and CPU ceilings, the
+# stop timeout — is in the half that stays silent.
+#
+# Cross-compiling is not a substitute. `GOOS=linux go build` proves the code
+# COMPILES for Linux; it runs no assertion, and `go build` does not even look at
+# _test.go files. A Linux test binary cannot be executed here either (`exec
+# format error`). Running them needs Linux, which means a container.
+#
+# The work itself is in ci.sh, the image in Dockerfile, the wiring in the repo's
+# compose.yml. This file is only the front door: it exists so that Docker being
+# down is a sentence rather than a stack trace.
+
+set -eu
+
+cd "$(dirname "$0")"
+
+# Docker being down must be a loud failure, never a skip.
+#
+# A script that "passes" because it ran nothing is the exact problem this closes
+# — it would restore the green-while-testing-nothing state, with more confidence
+# attached to it than before.
+if ! docker info >/dev/null 2>&1; then
+  echo "test-linux: Docker is not running." >&2
+  echo "  The Linux-only tests cannot run without it, and skipping them would" >&2
+  echo "  report success for a suite that never executed. Start Docker and" >&2
+  echo "  re-run, or push and let the 'bay' CI job cover it." >&2
+  exit 1
+fi
+
+echo "test-linux: reproducing the 'bay' CI job in a container"
+
+# `run --rm`, not `up`: this is a task, and its exit code is the whole result.
+# Compose rebuilds the image by itself when the Dockerfile or go.mod moves, so
+# there is no staleness to manage here.
+exec docker compose -f ../../compose.yml run --rm --build bay-test

--- a/compose.yml
+++ b/compose.yml
@@ -29,3 +29,31 @@ services:
       - "11883:1883"
     environment:
       EMQX_ALLOW_ANONYMOUS: "true"
+
+  # Bay's checks, on the platform Bay ships for.
+  #
+  # The odd one out in this file: everything above is a daemon that stays up
+  # while you develop, this is a task that runs once and exits. Hence the
+  # profile — without it, `docker compose up` would start a test run alongside
+  # the databases and sit there having "failed" to stay alive.
+  #
+  # Reached through `yarn w bay test:linux`, never directly, because Docker
+  # being down has to be a loud, explained failure rather than a stack trace.
+  bay-test:
+    profiles: ["tools"]
+    # No build args, and that is deliberate. Compose interpolates the WHOLE file
+    # before it looks at profiles, so a `${VAR:?}` here would make a plain
+    # `docker compose up` — the everyday command that starts postgres and redis
+    # — fail on a variable belonging to a service it was never going to start.
+    #
+    # The Go version is therefore pinned in the Dockerfile, and ci.sh asserts at
+    # run time that it matches go.mod. A checked duplicate beats a required
+    # variable that breaks everything else.
+    build:
+      context: ./apps/bay
+    volumes:
+      # Read-only on purpose. The container runs as root, and this is the only
+      # host path it can see — so there is no way for a test run to leave
+      # root-owned files in the working tree. Everything Go writes (build cache,
+      # module cache) lives inside the container.
+      - ./apps/bay:/src:ro

--- a/yarn.lock
+++ b/yarn.lock
@@ -6386,6 +6386,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"bay@workspace:apps/bay":
+  version: 0.0.0-use.local
+  resolution: "bay@workspace:apps/bay"
+  languageName: unknown
+  linkType: soft
+
 "benchmark@workspace:apps/benchmark":
   version: 0.0.0-use.local
   resolution: "benchmark@workspace:apps/benchmark"


### PR DESCRIPTION
Opening Bay to a team means 10-20 prototypes on one VPS. The starting question was whether that needs VPS agents or more RAM.

**Neither.** With the measured numbers — 87MB RSS per app under cgroup — twenty apps come to ~2.2GB against the machine's 3.8GB. They already fit, with room. So this fixes the three things that actually break first, none of which is memory.

## What's in it

**Releases are pruned.** Nothing ever deleted one. Twenty apps fill 40GB in weeks, and a full disk does not take down the app being deployed — it takes down every app on the host, plus the backups and Bay's own state writes. `--keep-releases 5`, floored at 2 so automatic rollback still has a target. Runs at startup *before* apps start, because on an already-full disk the deploy fails during the unpack and the post-deploy prune would never be reached.

**CPU is capped.** `MemoryMax` already stopped one app eating the host's RAM; nothing stopped it eating the CPU. On two vCPUs a prototype in a tight loop degrades the other nineteen *and* Bay's own proxy — one broken app becoming a site-wide outage. `CPUQuota` is derived (`NumCPU × 50%`, floored at 100%) so the rule "no app takes more than half the machine" survives the VPS growing.

**Unused apps are visible.** The proxy records when each app last *answered*, and bay-admin shows `Quiet 4 months · 3 crons` past thirty days. With twenty prototypes the question stops being "is this broken" and becomes "which of these can I delete".

**The Go suite runs on Linux.** `yarn w bay test:linux` reproduces the `bay` CI job in a container. `go test` on macOS is green while running 5 of 12 tests in `internal/runner` — the other 7 are `//go:build linux` and simply do not exist there, silently.

**A flaky test is fixed.** `health.WaitReady` reported its own deadline instead of what the app said, which was both a bad error message and a 1-in-6 CI failure.

## Notable decisions

- **Scale-to-zero was designed and then dropped.** `JobProvider` registers a `*/15` sweep in the manifest of any app using `$job`, so no real app would ever accumulate 15 minutes of idle — sleep would have been a no-op. The full reasoning, including the cron options weighed, is in Lore folio #23.
- **Traffic counting ignores requests the app refused.** Let's Encrypt publishes every certificate to the Certificate Transparency logs, so every Bay subdomain is publicly enumerable within minutes and gets scanned forever. Counting raw requests would show every abandoned prototype as freshly used — the one reading this feature exists to prevent.
- **The response status is read via `ReverseProxy.ModifyResponse`, never by wrapping the `ResponseWriter`.** A wrapper only forwards the interfaces it declares: losing `http.Flusher` buffers Alepha's streaming SSR head flush, losing `http.Hijacker` makes websocket upgrades fail outright. Both silent at compile time.
- **`CPUWeight` and `IOWeight` were considered and dropped.** Both default to 100 on every unit, so setting them identically everywhere does nothing. Only a hard ceiling protects when all apps are configured the same.
- **The `yarn v` budget moves from 5 to 10 minutes.** Not for Bay, which is 5% of the runtime — measured without it, the pipeline already ran 331s, 522s and 359s, so the old rule was being violated on every run.

## Verification

- `yarn v` green (376s), `yarn v --fast` green (77s)
- Go suite green on macOS **and** on Linux in a container, where 7 additional tests exist
- Each of the three commits independently builds and tests green
- Flake measured before and after: 1 failure in 6 full Linux runs → 0 in 10
- Mutation-checked the load-bearing assertions: unwiring `ModifyResponse`, removing the release-date fallback, and moving the quiet threshold each turn a named test red