### PR TITLE
fix(server): un champ fichier optionnel reste du multipart

### DIFF
--- a/packages/alepha/src/core/helpers/FileLike.ts
+++ b/packages/alepha/src/core/helpers/FileLike.ts
@@ -78,8 +78,15 @@ export type FileSchema = ZType;
 export const isTypeFile = (value: ZType): value is FileSchema => {
   // The format tag lives in zod's `.meta()`, read via `z.schema.format` — there
   // is no own `format` property to test for.
+  //
+  // Unwrapped first: `.optional()` wraps the schema in a ZodOptional whose own
+  // `.meta()` is empty, so the tag sits inside it. Reading the wrapper made
+  // `z.file().optional()` answer "not a file" — and a field that is merely not
+  // mandatory got decoded as text instead of materialised as bytes.
   return (
-    !!value && typeof value === "object" && z.schema.format(value) === "binary"
+    !!value &&
+    typeof value === "object" &&
+    z.schema.format(z.schema.unwrap(value)) === "binary"
   );
 };
 
@@ -92,8 +99,12 @@ export const isTypeFile = (value: ZType): value is FileSchema => {
  * arrive, once — so the ceiling stops being "what fits in RAM".
  */
 export const isTypeStream = (value: ZType): value is StreamSchema => {
+  // Unwrapped for the same reason as {@link isTypeFile}: an optional stream is
+  // still a stream, and reading the wrapper's empty `.meta()` said otherwise.
   return (
-    !!value && typeof value === "object" && z.schema.format(value) === "stream"
+    !!value &&
+    typeof value === "object" &&
+    z.schema.format(z.schema.unwrap(value)) === "stream"
   );
 };
 

--- a/packages/alepha/src/server/core/__tests__/OptionalFileMultipart.spec.ts
+++ b/packages/alepha/src/server/core/__tests__/OptionalFileMultipart.spec.ts
@@ -1,0 +1,179 @@
+import { Alepha, type FileLike, z } from "alepha";
+import {
+  $route,
+  AlephaServer,
+  isMultipart,
+  ServerProvider,
+} from "alepha/server";
+import { describe, it } from "vitest";
+
+const BOUNDARY = "----AlephaBoundary";
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/**
+ * One text field and one file part, exactly as a browser sends them.
+ */
+const bodyOf = (): Blob => {
+  const encoder = new TextEncoder();
+  const head = encoder.encode(
+    `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="title"\r\n\r\n` +
+      `a report\r\n` +
+      `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="screenshot"; filename="shot.png"\r\n` +
+      `Content-Type: image/png\r\n\r\n`,
+  );
+  const tail = encoder.encode(`\r\n--${BOUNDARY}--\r\n`);
+  const out = new Uint8Array(
+    new ArrayBuffer(head.length + PNG.length + tail.length),
+  );
+  out.set(head, 0);
+  out.set(PNG, head.length);
+  out.set(tail, head.length + PNG.length);
+  return new Blob([out]);
+};
+
+/**
+ * A file field that is merely not mandatory is still a file field.
+ *
+ * `z.file()` tags the schema `format: "binary"` through `.meta()`, and both
+ * ends read that tag: the client to build a FormData, the server to parse one.
+ * `.optional()` returns a NEW ZodOptional whose own `.meta()` is empty, so
+ * reading the wrapper answered `undefined` and the two ends agreed to do
+ * nothing — the upload went out as JSON and came back decoded as text, with no
+ * error anywhere to say so.
+ */
+describe("an optional file field is still multipart", () => {
+  it("is detected on the schema, wrapper or not", ({ expect }) => {
+    expect(isMultipart({ schema: { body: z.object({ f: z.file() }) } })).toBe(
+      true,
+    );
+    expect(
+      isMultipart({ schema: { body: z.object({ f: z.file().optional() }) } }),
+    ).toBe(true);
+    expect(
+      isMultipart({ schema: { body: z.object({ f: z.stream().optional() }) } }),
+    ).toBe(true);
+    // Nullable and defaulted wrappers peel the same way.
+    expect(
+      isMultipart({
+        schema: { body: z.object({ f: z.file().nullable() }) },
+      }),
+    ).toBe(true);
+    // Still false when there is genuinely no file in the body.
+    expect(isMultipart({ schema: { body: z.object({ f: z.text() }) } })).toBe(
+      false,
+    );
+  });
+
+  it("reaches the handler as bytes, not as decoded text", async ({
+    expect,
+  }) => {
+    const alepha = Alepha.create({
+      env: { LOG_LEVEL: "error", SERVER_PORT: 0, SERVER_HOST: "127.0.0.1" },
+    });
+
+    class ReportApi {
+      submit = $route({
+        method: "POST",
+        path: "/report",
+        schema: {
+          body: z.object({
+            title: z.text(),
+            screenshot: z.file({ maxBytes: 1024 * 1024 }).optional(),
+          }),
+        },
+        handler: async ({ body }) => {
+          const file = body.screenshot as FileLike | undefined;
+          const bytes = file ? new Uint8Array(await file.arrayBuffer()) : null;
+          return {
+            title: body.title,
+            // `type` is what a handler routes on to accept or refuse an
+            // upload; it is undefined on anything that was decoded as text.
+            type: file?.type,
+            filename: file?.name,
+            head: bytes ? [...bytes.subarray(0, 4)] : null,
+            size: bytes?.length ?? 0,
+          } as never;
+        },
+      });
+    }
+
+    alepha.with(AlephaServer);
+    alepha.inject(ReportApi);
+    const server = alepha.inject(ServerProvider);
+    await alepha.start();
+
+    const res = await fetch(`${server.hostname}/report`, {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${BOUNDARY}` },
+      body: bodyOf(),
+    });
+
+    expect(res.status).toBe(200);
+    const out = (await res.json()) as {
+      title: string;
+      type?: string;
+      filename?: string;
+      head: number[] | null;
+      size: number;
+    };
+
+    expect(out.title).toBe("a report");
+    expect(out.type).toBe("image/png");
+    expect(out.filename).toBe("shot.png");
+    // The PNG magic number, byte for byte: proof the part was materialised
+    // rather than run through a text decoder.
+    expect(out.head).toEqual([0x89, 0x50, 0x4e, 0x47]);
+    expect(out.size).toBe(PNG.length);
+
+    await alepha.stop();
+  });
+
+  it("still accepts the request when the optional file is absent", async ({
+    expect,
+  }) => {
+    const alepha = Alepha.create({
+      env: { LOG_LEVEL: "error", SERVER_PORT: 0, SERVER_HOST: "127.0.0.1" },
+    });
+
+    class ReportApi {
+      submit = $route({
+        method: "POST",
+        path: "/report",
+        schema: {
+          body: z.object({
+            title: z.text(),
+            screenshot: z.file().optional(),
+          }),
+        },
+        handler: async ({ body }) =>
+          ({ title: body.title, hasFile: !!body.screenshot }) as never,
+      });
+    }
+
+    alepha.with(AlephaServer);
+    alepha.inject(ReportApi);
+    const server = alepha.inject(ServerProvider);
+    await alepha.start();
+
+    const body = new Blob([
+      `--${BOUNDARY}\r\n` +
+        `Content-Disposition: form-data; name="title"\r\n\r\n` +
+        `no shot\r\n` +
+        `--${BOUNDARY}--\r\n`,
+    ]);
+
+    const res = await fetch(`${server.hostname}/report`, {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${BOUNDARY}` },
+      body,
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ title: "no shot", hasFile: false });
+
+    await alepha.stop();
+  });
+});

--- a/packages/alepha/src/server/core/helpers/isMultipart.ts
+++ b/packages/alepha/src/server/core/helpers/isMultipart.ts
@@ -28,7 +28,13 @@ export const isMultipart = (options: {
       // read at BOTH ends — the client builds the FormData from it, the server
       // decides to parse one — so missing a format means the two agree to do
       // nothing, and the upload silently arrives as an ordinary body.
-      const format = z.schema.format(properties[key]);
+      //
+      // `unwrap` first: `.optional()` returns a NEW ZodOptional whose own
+      // `.meta()` is empty, so the `format: "binary"` tag sits on the schema
+      // *inside* the wrapper. Reading the wrapper answered undefined, which
+      // made `z.file().optional()` — an upload that is merely not mandatory —
+      // silently not multipart at either end.
+      const format = z.schema.format(z.schema.unwrap(properties[key]));
       if (format === "binary" || format === "stream") {
         return true;
       }


### PR DESCRIPTION
## Le problème

`z.file()` pose son marqueur `format: "binary"` dans le `.meta()` du schéma, et **les deux bouts** lisent ce marqueur : le client pour construire un `FormData`, le serveur pour décider d'en parser un.

`.optional()` renvoie un **nouveau** `ZodOptional` dont le `.meta()` est vide. Le marqueur se retrouve sur le schéma *à l'intérieur* du wrapper, et le lire sur le wrapper répond `undefined`.

Les deux bouts se mettaient donc d'accord pour ne rien faire :

1. `$action.getBodyContentType()` ne voyait pas de fichier → la route était publiée dans `/api/_links` **sans** `contentType: multipart/form-data` ;
2. côté navigateur, `HttpClient` encodait le corps en JSON (le `File` devenait `{}`) ;
3. côté serveur, `ServerMultipartProvider` passait la part dans `codec.decode(...textOf(part))` — le binaire décodé **comme du texte** ;
4. `file.type` était `undefined`, et le handler rejetait la requête.

Aucune erreur nulle part pour le dire : dans l'application qui a levé le bug, le bouton d'envoi paraissait simplement mort.

## Le correctif

Déballer avant de lire le format, dans les trois prédicats qui en dépendent :

- `isMultipart` — décide du transport aux deux bouts ;
- `isTypeFile` / `isTypeStream` — décident de la façon dont une part est consommée.

Un champ `.nullable()` ou pourvu d'un `.default()` se déballe de la même manière (`z.schema.unwrap` pèle les trois).

## Tests

`packages/alepha/src/server/core/__tests__/OptionalFileMultipart.spec.ts`, 3 cas :

- détection sur le schéma, avec et sans wrapper (`optional`, `nullable`, `stream`), et toujours `false` quand il n'y a pas de fichier ;
- aller-retour complet sur une vraie route : la part arrive avec son `type`, son `name`, et les octets du PNG intacts (nombre magique vérifié octet par octet) — ce qu'un décodage texte ne peut pas produire ;
- la requête reste acceptée quand le fichier optionnel est absent.

Vérifié que le spec **échoue** sans le correctif (500 au lieu de 200).

Suite complète : 5329 tests passés, 511 fichiers, lint et typecheck verts.